### PR TITLE
Merge PRs with the opam-repository master branch

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -32,6 +32,7 @@
   (capnp-rpc-unix (>= 0.5.0))
   opam-repo-ci-api
   (routes (< 0.8.0))
+  (opam-format (>= 2.0.0))
   conf-libev
   (dockerfile (>= 6.3.0))
   (dockerfile-opam (>= 6.3.0))

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -1,13 +1,19 @@
 open Lwt.Infix
 open Current.Syntax
 
-type key = {
-  src : Current_git.Commit.t;
-}
-
 let pool = Current.Pool.create ~label:"analyse" 2
 
+let ( / ) = Filename.concat
 let ( >>!= ) = Lwt_result.bind
+
+let read_file ~max_len path =
+  let ch = open_in path in
+  Fun.protect ~finally:(fun () -> close_in ch)
+    (fun () ->
+       let len = in_channel_length ch in
+       if len <= max_len then really_input_string ch len
+       else Fmt.failwith "File %S too big (%d bytes)" path len
+    )
 
 module Analysis = struct
   type t = {
@@ -27,51 +33,102 @@ module Analysis = struct
   let is_duniverse _ = false
 
   let ocamlformat_source _ = None
+  
+  let check_opam_version =
+    let version_2 = OpamVersion.of_string "2" in
+    fun name opam ->
+      let opam_version = OpamFile.OPAM.opam_version opam in
+      if OpamVersion.compare opam_version version_2 < 0 then
+        Fmt.failwith "Package %S uses unsupported opam version %s (need >= 2)" name (OpamVersion.to_string opam_version)
 
-  let of_dir ~head ~job dir =
+  let of_dir ~job ~master dir =
     (* TODO: Check if the PR added an opam file in packages/<pkg> instead of packages/<pkg>/<pkg>.<ver> (common mistake) *)
     (* TODO: Split modified vs. added (using git diff --name-status) *)
-    let (_, master) = Current_git.Commit.hash head in
-    let master = Option.get master in
-    let fmt = Printf.sprintf in
-    let cmd = "", [| "sh"; "-c"; fmt {|git diff %s | sed -E -n -e 's,^\+\+\+ b/packages/[^/]*/([^/]*)/.*,\1,p'|} master |] in
-    Current.Process.check_output ~cwd:dir ~cancellable:true ~job cmd >>!= fun output ->
-    let opam_files =
-      String.split_on_char '\n' output
-      |> List.filter (fun s -> not (String.equal s ""))
-      |> List.sort String.compare
-    in
-    let r = { opam_files } in
-    Current.Job.log job "@[<v2>Results:@,%a@]" Yojson.Safe.(pretty_print ~std:true) (to_yojson r);
-    Lwt.return (Ok r)
+    let master = Current_git.Commit.hash master in
+    let cmd = "", [| "git"; "merge"; master |] in
+    Current.Process.exec ~cwd:dir ~cancellable:true ~job cmd >>= function
+    | Error (`Msg msg) ->
+      Current.Job.log job "Merge failed: %s" msg;
+      Lwt_result.fail (`Msg "Cannot merge to master - please rebase!")
+    | Ok () ->
+      let cmd = "", [| "git"; "diff"; "--name-only"; master; "packages/" |] in
+      Current.Process.check_output ~cwd:dir ~cancellable:true ~job cmd >>!= fun output ->
+      let opam_files =
+        String.split_on_char '\n' output
+        |> List.filter_map (fun path ->
+            match String.split_on_char '/' path with
+            | [] | [""] | ["packages"] | ["packages"; _] -> None
+            | "packages" :: name :: package :: _ ->
+              let nme = OpamPackage.Name.of_string name in
+              let pkg = OpamPackage.of_string package in
+              if OpamPackage.Name.compare nme (OpamPackage.name pkg) <> 0 then
+                Fmt.failwith "Mismatch between package dir name %S and parent directory name %S" package name;
+              Some pkg
+            | _ ->
+              Fmt.failwith "Unexpected path %S in output (expecting 'packages/name/pkg/...')" path
+          )
+        |> List.sort_uniq OpamPackage.compare
+        |> List.map (fun pkg ->
+            let path =
+              Printf.sprintf "packages/%s/%s/opam"
+                (OpamPackage.name_to_string pkg)
+                (OpamPackage.to_string pkg)
+            in
+            (* Check it exists, parses, and is the right version. *)
+            let content = read_file ~max_len:102400 (Fpath.to_string dir / path) in
+            let opam = OpamFile.OPAM.read_from_string content in
+            check_opam_version path opam;
+            OpamPackage.to_string pkg
+          )
+      in
+      let r = { opam_files } in
+      Current.Job.log job "@[<v2>Results:@,%a@]" Yojson.Safe.(pretty_print ~std:true) (to_yojson r);
+      Lwt.return (Ok r)
 end
 
 module Examine = struct
   type t = No_context
 
   module Key = struct
-    type t = key
+    type t = {
+      src : Current_git.Commit.t;
+    }
 
     let digest {src} =
-      fst (Current_git.Commit.hash src)
+      Current_git.Commit.hash src
   end
 
-  module Value = Analysis
+  module Value = struct
+    type t = {
+      master : Current_git.Commit.t;
+    }
 
-  let id = "ci-analyse"
+    let digest { master } =
+      let json = `Assoc [
+          "master", `String (Current_git.Commit.hash master);
+        ]
+      in
+      Yojson.Safe.to_string json
+  end
 
-  let build No_context job {src} =
+  module Outcome = Analysis
+
+  let id = "opam-ci-analyse"
+
+  let run No_context job { Key.src } { Value.master } =
     Current.Job.start job ~pool ~level:Current.Level.Harmless >>= fun () ->
-    Current_git.with_checkout ~enable_submodules:false ~job src (Analysis.of_dir ~head:src ~job)
+    Current_git.with_checkout ~job src (Analysis.of_dir ~master ~job)
 
   let pp f _ = Fmt.string f "Analyse"
 
   let auto_cancel = false
+  let latched = true
 end
 
-module Examine_cache = Current_cache.Make(Examine)
+module Examine_cache = Current_cache.Generic(Examine)
 
-let examine src =
+let examine ~master src =
   Current.component "Analyse" |>
-  let> src = src in
-  Examine_cache.get Examine.No_context {src}
+  let> src = src
+  and> master = master in
+  Examine_cache.run Examine.No_context { Examine.Key.src } { Examine.Value.master }

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -45,7 +45,7 @@ module Analysis = struct
     (* TODO: Check if the PR added an opam file in packages/<pkg> instead of packages/<pkg>/<pkg>.<ver> (common mistake) *)
     (* TODO: Split modified vs. added (using git diff --name-status) *)
     let master = Current_git.Commit.hash master in
-    let cmd = "", [| "git"; "merge"; master |] in
+    let cmd = "", [| "git"; "merge"; "-q"; "--"; master |] in
     Current.Process.exec ~cwd:dir ~cancellable:true ~job cmd >>= function
     | Error (`Msg msg) ->
       Current.Job.log job "Merge failed: %s" msg;

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -7,5 +7,6 @@ module Analysis : sig
 end
 
 val examine :
+  master:Current_git.Commit.t Current.t ->
   Current_git.Commit.t Current.t ->
   Analysis.t Current.t

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -109,7 +109,7 @@ module Op = struct
     Current.Job.start ~timeout:build_timeout ~pool job ~level:Current.Level.Average >>= fun () ->
     Current_git.with_checkout ~job commit @@ fun dir ->
     (* Merge with master. The merge should work because we already tried this in the analysis step. *)
-    let cmd = "", [| "git"; "merge"; master |] in
+    let cmd = "", [| "git"; "merge"; "-q"; "--"; master |] in
     Current.Process.exec ~cwd:dir ~cancellable:true ~job cmd >>!= fun () ->
     (* Write Dockerfile *)
     Current.Job.write job (Fmt.strf "Writing BuildKit Dockerfile:@.%s@." dockerfile);

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -25,5 +25,6 @@ val v :
   revdep:string option ->
   with_tests:bool ->
   pkg:string ->
+  master:Current_git.Commit.t Current.t ->
   Current_git.Commit.t Current.t ->
   Current_docker.Raw.Image.t Current.t

--- a/lib/builder.ml
+++ b/lib/builder.ml
@@ -6,7 +6,6 @@ type t = {
 
 let build { docker_context; pool; build_timeout } ~dockerfile source =
   Current_docker.Raw.build (`Git source)
-    ~enable_submodules:false
     ~dockerfile
     ~docker_context
     ~pool

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
   (name opam_repo_ci)
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
-  (libraries logs current current_docker current_github current.term current.cache dockerfile ppx_deriving_yojson.runtime ocaml-version))
+  (libraries logs current current_docker current_github current.term current.cache dockerfile ppx_deriving_yojson.runtime ocaml-version opam-format))

--- a/opam-repo-ci-service.opam
+++ b/opam-repo-ci-service.opam
@@ -15,6 +15,7 @@ depends: [
   "capnp-rpc-unix" {>= "0.5.0"}
   "opam-repo-ci-api"
   "routes" {< "0.8.0"}
+  "opam-format" {>= "2.0.0"}
   "conf-libev"
   "dockerfile" {>= "6.3.0"}
   "dockerfile-opam" {>= "6.3.0"}

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -32,7 +32,7 @@ let set_active_refs ~repo xs =
     xs |> List.map @@ fun x ->
     let commit = Github.Api.Commit.id x in
     let gref = Git.Commit_id.gref commit in
-    let (hash, _) = Git.Commit_id.hash commit in
+    let hash = Git.Commit_id.hash commit in
     (gref, hash)
   );
   xs
@@ -62,7 +62,7 @@ let once_done x f =
   | Error _ -> Skip
   | Ok x -> f x
 
-let build_with_docker ~analysis source =
+let build_with_docker ~analysis ~master source =
   let pipeline =
     once_done analysis @@ fun analysis ->
     let pkgs = Analyse.Analysis.opam_files analysis in
@@ -74,10 +74,10 @@ let build_with_docker ~analysis source =
       in
       List.map (fun pkg ->
         let prefix = pkg^status_sep^label in
-        let image = Build.v ~spec ~schedule:weekly ~revdep:None ~with_tests:false ~pkg source in
+        let image = Build.v ~spec ~schedule:weekly ~revdep:None ~with_tests:false ~pkg ~master source in
         let tests =
           once_done image @@ fun _ ->
-          Job (prefix^status_sep^"tests", job_id (Build.v ~spec ~schedule:weekly ~revdep:None ~with_tests:true ~pkg source))
+          Job (prefix^status_sep^"tests", job_id (Build.v ~spec ~schedule:weekly ~revdep:None ~with_tests:true ~pkg ~master source))
         in
         let revdeps =
           if revdeps then
@@ -94,10 +94,10 @@ let build_with_docker ~analysis source =
                 List.map (fun revdep ->
                   let prefix = prefix^status_sep^revdep in
                   let revdep = Some revdep in
-                  let image = Build.v ~spec ~schedule:weekly ~revdep ~with_tests:false ~pkg source in
+                  let image = Build.v ~spec ~schedule:weekly ~revdep ~with_tests:false ~pkg ~master source in
                   let tests =
                     once_done image @@ fun _ ->
-                    Job (prefix^status_sep^"tests", job_id (Build.v ~spec ~schedule:weekly ~revdep ~with_tests:true ~pkg source))
+                    Job (prefix^status_sep^"tests", job_id (Build.v ~spec ~schedule:weekly ~revdep ~with_tests:true ~pkg ~master source))
                   in
                   Stage [Job (prefix, job_id image); Dynamic tests]
                 )
@@ -185,16 +185,26 @@ let summarise results =
     | ok, err, _ -> list_errors ~ok err     (* Some errors found - report *)
 
 let get_prs repo =
-  let+ refs =
+  let refs =
     Current.component "Get PRs" |>
     let> (api, repo) = repo in
     Github.Api.refs api repo
   in
+  let master =
+    refs
+    |> Current.map (Github.Api.Ref_map.find (`Ref "refs/heads/master"))
+    |> Current.map Github.Api.Commit.id
+    |> Git.fetch
+  in
+  let prs =
+    let+ refs = refs in
   Github.Api.Ref_map.fold begin fun key head acc ->
     match key with
     | `Ref _ -> acc (* Skip branches, only check PRs *)
     | `PR _ -> head :: acc
   end refs []
+  in
+  master, prs
 
 let rec get_jobs_aux f = function
   | Skip -> Current.return []
@@ -219,10 +229,11 @@ let get_jobs builds =
 
 let local_test repo () =
   let src = Git.Local.head_commit repo in
-  let analysis = Analyse.examine src in
+  let master = Git.Local.commit_of_ref repo "refs/heads/master" in
+  let analysis = Analyse.examine ~master src in
   Current.component "summarise" |>
   let** result =
-    build_with_docker ~analysis src |>
+    build_with_docker ~analysis ~master src |>
     summarise
   in
   Current.of_output result
@@ -231,11 +242,12 @@ let v ~app () =
   Github.App.installations app |> Current.list_iter (module Github.Installation) @@ fun installation ->
   let repos = Github.Installation.repositories installation in
   repos |> Current.list_iter (module Github.Api.Repo) @@ fun repo ->
-  let prs = get_prs repo |> set_active_refs ~repo in
+  let master, prs = get_prs repo in
+  let prs = set_active_refs ~repo prs in
   prs |> Current.list_iter (module Github.Api.Commit) @@ fun head ->
   let src = Git.fetch (Current.map Github.Api.Commit.id head) in
-  let analysis = Analyse.examine src in
-  let builds = build_with_docker ~analysis src in
+  let analysis = Analyse.examine ~master src in
+  let builds = build_with_docker ~analysis ~master src in
   let summary = summarise builds in
   let status =
     let+ summary = summary in


### PR DESCRIPTION
It now uses the upstream OCurrent, since the merging is now done by the CI, not in OCurrent. When `master` updates, the rebuild is done in the background (it still shows as successful in GitHub until the new result is known, rather than switching to pending).

The `sed` invocation didn't work for me, so I replaced it with some OCaml code, which is probably neater anyway. I added a check that the opam file is version 2 and that it's in the right place.

I updated the instructions for reproducing the build locally.

With these changes, I was able to run `opam-repo-ci-local` on a local clone of opam-repository.

Note: this also removes the `~enable_submodules` option. We might want to bring that back at some point, but I suspect that people trying to add submodules to opam-repository is not an urgent problem at the moment.

We may want to upstream other changes from the branch at some point too. In particular, the graph looks a bit messy. But let's get this working first, then update to the new solvers, then see if we still need that...