### PR TITLE
Remove nested use of Current.t from pipeline

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -13,6 +13,7 @@
  (synopsis "Cap'n Proto API for opam-repo-ci")
  (depends
   (dune (>= "1.11"))
+  (ocaml (>= "4.10.0"))
   current_rpc
   (capnp (>= 3.4.0))
   capnp-rpc-lwt
@@ -24,6 +25,7 @@
  (conflicts (ocaml-migrate-parsetree (= "1.7.1")))
  (depends
   (dune (>= "1.11"))
+  (ocaml (>= "4.10.0"))
   current_git
   current_github
   current_docker
@@ -46,6 +48,7 @@
  (conflicts (ocaml-migrate-parsetree (= "1.7.1")))
  (depends
   (dune (>= "1.11"))
+  (ocaml (>= "4.10.0"))
   current_rpc
   current_ansi
   prometheus-app
@@ -65,6 +68,7 @@
  (synopsis "Command-line client for opam-repo-ci")
  (depends
   (dune (>= "1.11"))
+  (ocaml (>= "4.10.0"))
   current_rpc
   capnp-rpc-unix
   opam-repo-ci-api

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -146,15 +146,14 @@ let pread ~spec image ~args =
   let> { Spec.platform = {Platform.builder; _}; _ } = spec in
   Builder.pread builder ~args image
 
-let build ~spec ~base ~revdep ~with_tests ~pkg ~master commit =
-  Current.component "build" |>
+let v ~spec ~base ?revdep ~with_tests ~pkg ~master commit =
+  Current.component (if with_tests then "test" else "build") |>
   let> { Spec.platform; ty; label } = spec
   and> base = base
+  and> pkg = pkg
   and> commit = commit
+  and> revdep = Current.option_seq revdep
   and> master = master in
   let { Platform.builder; variant; _ } = platform in
+  let revdep = Option.map OpamPackage.to_string revdep in
   BC.run builder { Op.Key.commit; label; revdep; with_tests; pkg } { Op.Value.base; ty; variant; master }
-
-let v ~schedule ~spec ~revdep ~with_tests ~pkg ~master source =
-  let base = pull ~schedule spec in
-  build ~spec ~base ~revdep ~with_tests ~pkg ~master source

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -19,12 +19,17 @@ val pread :
   args:string list ->
   string Current.t
 
-val v :
+val pull :
   schedule:Current_cache.Schedule.t ->
+  Spec.t Current.t ->
+  Current_docker.Raw.Image.t Current.t
+
+val v :
   spec:Spec.t Current.t ->
-  revdep:string option ->
+  base:Current_docker.Raw.Image.t Current.t ->
+  ?revdep:OpamPackage.t Current.t ->
   with_tests:bool ->
-  pkg:OpamPackage.t ->
+  pkg:OpamPackage.t Current.t ->
   master:Current_git.Commit.t Current.t ->
   Current_git.Commit.t Current.t ->
   Current_docker.Raw.Image.t Current.t

--- a/opam-repo-ci-api.opam
+++ b/opam-repo-ci-api.opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/ocurrent/opam-repo-ci"
 bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
 depends: [
   "dune" {>= "1.11"}
+  "ocaml" {>= "4.10.0"}
   "current_rpc"
   "capnp" {>= "3.4.0"}
   "capnp-rpc-lwt"

--- a/opam-repo-ci-client.opam
+++ b/opam-repo-ci-client.opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/ocurrent/opam-repo-ci"
 bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
 depends: [
   "dune" {>= "1.11"}
+  "ocaml" {>= "4.10.0"}
   "current_rpc"
   "capnp-rpc-unix"
   "opam-repo-ci-api"

--- a/opam-repo-ci-service.opam
+++ b/opam-repo-ci-service.opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/ocurrent/opam-repo-ci"
 bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
 depends: [
   "dune" {>= "1.11"}
+  "ocaml" {>= "4.10.0"}
   "current_git"
   "current_github"
   "current_docker"

--- a/opam-repo-ci-web.opam
+++ b/opam-repo-ci-web.opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/ocurrent/opam-repo-ci"
 bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
 depends: [
   "dune" {>= "1.11"}
+  "ocaml" {>= "4.10.0"}
   "current_rpc"
   "current_ansi"
   "prometheus-app"

--- a/service/node.ml
+++ b/service/node.ml
@@ -1,0 +1,58 @@
+open Current.Syntax
+
+type t =
+  | Root of t list
+  | Branch of { label : string; children : t list }
+  | Leaf of
+      {
+        label : string;
+        job_id : Current.job_id option;
+        result : [`Built | `Checked] Current_term.Output.t;
+      }
+
+let status_sep = String.make 1 Opam_repo_ci_api.Common.status_sep
+
+let job_id job =
+  let+ md = Current.Analysis.metadata job in
+  match md with
+  | Some { Current.Metadata.job_id; _ } -> job_id
+  | None -> None
+
+let root children = Root children
+let branch ~label children = Branch { label; children }
+let leaf ~label ~job_id result = Leaf { label; job_id; result }
+
+let of_job ~label kind job =
+  let+ job_id = job_id job
+  and+ result = job |> Current.map (fun _ -> kind) |> Current.state ~hidden:true
+  in
+  leaf ~label ~job_id result
+
+let rec flatten ~prefix f = function
+  | Root children ->
+    List.concat_map (flatten ~prefix f) children
+  | Branch { label; children } ->
+    let prefix = prefix ^ label ^ status_sep in
+    List.concat_map (flatten ~prefix f) children
+  | Leaf { label; job_id; result } ->
+    let label = prefix ^ label in
+    [f ~label ~job_id ~result]
+
+let flatten f t = flatten f t ~prefix:""
+
+let pp_result f = function
+  | Ok `Built -> Fmt.string f "built"
+  | Ok `Checked -> Fmt.string f "checked"
+  | Error (`Active _) -> Fmt.string f "active"
+  | Error (`Msg m) -> Fmt.string f m
+
+let rec dump f = function
+  | Root children ->
+    Fmt.pf f "@[<v>%a@]"
+      (Fmt.(list ~sep:cut) dump) children
+  | Branch { label; children } ->
+    Fmt.pf f "@[<v2>%s%a@]"
+      label
+      Fmt.(list ~sep:nop (cut ++ dump)) children
+  | Leaf { label; job_id = _; result } ->
+    Fmt.pf f "%s (%a)" label pp_result result

--- a/service/node.mli
+++ b/service/node.mli
@@ -1,0 +1,23 @@
+type t
+(** A node in the tree of results. *)
+
+val branch : label:string -> t list -> t
+(** [branch ~label children] is a branch node. *)
+
+val root : t list -> t
+(** [root children] is a branch with no label, used for the root node. *)
+
+val of_job : label:string -> [ `Built | `Checked ] -> _ Current.t -> t Current.t
+(** [of_job kind job ~label] is a leaf node whose status is the state of [job]
+    but with the value replaced with [kind]. The job ID is extracted from the
+    job (so [job] must be a primitive). Although the result is a [Current.t] it
+    is always successful and immediately available. *)
+
+val flatten :
+  (label:string ->
+   job_id:string option ->
+   result:[ `Built | `Checked ] Current_term.Output.t -> 'a) ->
+  t -> 'a list
+(** [flatten f t] converts the tree to a list, applying [f] to each element. *)
+
+val dump : t Fmt.t


### PR DESCRIPTION
This removes the `pipeline` type and its nested currents. Instead, the result is a simple current whose value is the tree of labels, jobs IDs and results.

It also does the pull only once per package/platform, and adds some labels to the diagrams. This makes the diagrams quite readable with the plain upstream OCurrent. Eventually, the base image pulls should be moved to the top-level, as in ocaml-ci.

Example output (from `opam-repo-ci-local`):

![simplify](https://user-images.githubusercontent.com/554131/84650471-37d83b00-af00-11ea-99da-96c7b0fde9b3.png)
