### PR TITLE
Convert from GitHub app to OAuth

### DIFF
--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -1,5 +1,5 @@
 val local_test : Current_git.Local.t -> unit -> unit Current.t
 (** [local_test repo] is a pipeline that tests local repository [repo] as the CI would. *)
 
-val v : app:Current_github.App.t -> unit -> unit Current.t
+val v : repo:Current_github.Api.Repo.t -> unit -> unit Current.t
 (** The main opam-repo-ci pipeline. Tests everything configured for GitHub application [app]. *)

--- a/stack.yml
+++ b/stack.yml
@@ -10,7 +10,7 @@ secrets:
 services:
   ci:
     image: opam-repo-ci-service
-    command: --github-app-id 52344 --github-private-key-file /run/secrets/opam-repo-ci-github-key --github-account-whitelist "kit-ty-kate" --confirm above-average --confirm-auto-release 120 --capnp-address=tcp:ci:9000 --github-oauth /run/secrets/opam-repo-ci-oauth
+    command: --confirm above-average --confirm-auto-release 120 --capnp-address=tcp:ci:9000 --github-oauth /run/secrets/opam-repo-ci-oauth --repository=ocaml/opam-repository 
     environment:
       - "CI_PROFILE=production"
       - "PROGRESS_NO_TRUNC=1"
@@ -22,7 +22,7 @@ services:
       - 'capnp-secrets:/capnp-secrets'
     secrets:
       - 'opam-repo-ci-oauth'
-      - 'opam-repo-ci-github-key'
+      - 'opam-repo-ci-github-token'
     sysctls:
       - 'net.ipv4.tcp_keepalive_time=60'
     networks:


### PR DESCRIPTION
Apps are easy for users to install on multiple organisations, but for opam-repo-ci we just want to monitor one repository. The new `--repository` option can be used to control which one.