### PR TITLE
Precisely track revdeps by only allowing to run revdep tests when actually possible

### DIFF
--- a/lib/build.mli
+++ b/lib/build.mli
@@ -24,6 +24,7 @@ val v :
 
 val list_revdeps :
   t ->
+  with_tests:bool ->
   platform:Platform.t ->
   pkg:OpamPackage.t Current.t ->
   base:Current_docker.Raw.Image.t Current.t ->

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -68,13 +68,16 @@ let spec ~base ~variant ~revdep ~with_tests ~pkg =
 
 let revdeps ~base ~variant ~pkg =
   let open Obuilder_spec in
+  let pkg = Filename.quote (OpamPackage.to_string pkg) in
   { from = base;
     ops =
       setup_repository ~variant
       @ [
         run "echo '@@@OUTPUT' && \
-             opam list -s --color=never --depends-on %s --installable --all-versions --depopts && \
+             (opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --depopts && \
+              opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --depopts --with-test) \
+             | sort -u && \
              echo '@@@OUTPUT'"
-          (Filename.quote (OpamPackage.to_string pkg))
+          pkg pkg pkg pkg
       ]
   }

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -7,6 +7,7 @@ val spec :
   Obuilder_spec.stage
 
 val revdeps :
+  with_tests:bool ->
   base:string ->
   variant:string ->
   pkg:OpamPackage.t ->


### PR DESCRIPTION
This PR improves several things:
* to get the list of revdeps, opam-repo-ci is now using the `--coinstallable-with <pkg>` option from `opam list` to filter out the packages that won't be able to be installed. https://github.com/ocurrent/opam-repo-ci/pull/16 previously fixes this issue by ignoring the packages. However this is inefficient but with this method we can get the list reliably. Shout-out to @rjbou and @AltGr who took some time to answer my question.
* it also splits the call to opam list into two:
  - the first one is to get the regular revdeps
  - and the second one is to get the packages that are revdeps and that can also be tested

This allows to know precisely which packages are compatible and for what. With this we can remove the ` || test $? -eq 20` magic added in #16 and be more efficient by not spawning new jobs for nothing.

I hope this doesn't bother the rewrite of the new analysis phase using opam-0install's solver too much. I'm guessing revdeps integration in the rewrite is gonna come a bit later so hopefully this is useful in the meantime.