### PR TITLE
Minor fixes

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -39,6 +39,10 @@ let setup_repository ~variant =
     else
       []
   in
+  env "OPAMDOWNLOADJOBS" "1" :: (* Try to avoid github spam detection *)
+  env "OPAMERRLOGLEN" "0" :: (* Show the whole log if it fails *)
+  env "OPAMSOLVERTIMEOUT" "500" :: (* Increase timeout. Poor mccs is doing its best *)
+  env "OPAMPRECISETRACKING" "1" :: (* Mitigate https://github.com/ocaml/opam/issues/3997 *)
   user ~uid:1000 ~gid:1000 :: distro_extras @ opam_extras @ [
     copy ["."] ~dst:"/src/";
     run "opam repository set-url --strict default file:///src";

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -89,8 +89,8 @@ module Revdep = struct
     compare ((pkg1, with_tests) : OpamPackage.t * bool) (pkg2, options.with_tests)
 
   let pp =
-    Fmt.of_to_string (fun (pkg, {with_tests}) ->
-      Fmt.strf "(%s, {with_tests = %b})" (OpamPackage.to_string pkg) with_tests
+    Fmt.of_to_string (fun (pkg, {with_tests = _}) ->
+      Fmt.strf "%s" (OpamPackage.to_string pkg)
     )
 end
 


### PR DESCRIPTION
The first commit should make the graph look prettier, at the moment it's a bit bloated with the `{with_tests}` variable:
![scrn-2020-10-28-16-48-28](https://user-images.githubusercontent.com/2611789/97468643-6e59a400-193d-11eb-9518-7a9570d19304.png)

The second commit should fix timeouts as well as other issues encountered previously with mirage-ci/Datakit-CI.