### PR TITLE
Makes the user-facing logs prettier

### DIFF
--- a/service/node.ml
+++ b/service/node.ml
@@ -35,9 +35,9 @@ let rec flatten ~prefix f = function
     let prefix = prefix ^ label ^ status_sep in
     List.concat_map (flatten ~prefix f) children
   | Branch { label; action = Some { job_id; result }; children } ->
+    let prefix_children = prefix ^ label ^ status_sep in
     let label = prefix ^ label in
-    let prefix = prefix ^ label ^ status_sep in
-    f ~label ~job_id ~result :: List.concat_map (flatten ~prefix f) children
+    f ~label ~job_id ~result :: List.concat_map (flatten ~prefix:prefix_children f) children
 
 let flatten f t = flatten f t ~prefix:""
 

--- a/service/node.mli
+++ b/service/node.mli
@@ -1,5 +1,12 @@
+type action
+(** A result *)
+
 type t
 (** A node in the tree of results. *)
+
+val actioned_branch : label:string -> action -> t list -> t
+(** [actioned_branch ~label action children] is a branch node with an
+    action directly attached to the node itself. *)
 
 val branch : label:string -> t list -> t
 (** [branch ~label children] is a branch node. *)
@@ -7,8 +14,11 @@ val branch : label:string -> t list -> t
 val root : t list -> t
 (** [root children] is a branch with no label, used for the root node. *)
 
-val of_job : label:string -> [ `Built | `Checked ] -> _ Current.t -> t Current.t
-(** [of_job kind job ~label] is a leaf node whose status is the state of [job]
+val leaf : label:string -> action -> t
+(** [leaf ~label action] is a leaf node. *)
+
+val action : [ `Built | `Checked ] -> _ Current.t -> action Current.t
+(** [action kind job] is a result whose status is the state of [job]
     but with the value replaced with [kind]. The job ID is extracted from the
     job (so [job] must be a primitive). Although the result is a [Current.t] it
     is always successful and immediately available. *)

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -112,9 +112,7 @@ let combine_revdeps ~revdeps ~revdeps_with_tests =
 let test_revdeps ~ocluster ~master ~base ~platform ~pkg ~after:main_build source =
   let revdeps = Build.list_revdeps ~base ocluster ~with_tests:false ~platform ~pkg ~master source in
   let revdeps_with_tests = Build.list_revdeps ~base ocluster ~with_tests:true ~platform ~pkg ~master source in
-  let+ list_op = Node.of_job `Checked revdeps ~label:"list revdeps"
-  and+ list_with_tests_op = Node.of_job `Checked revdeps_with_tests ~label:"list revdeps with tests"
-  and+ tests =
+  let+ tests =
     let revdeps = combine_revdeps ~revdeps ~revdeps_with_tests in
     revdeps
     |> Current.gate ~on:main_build
@@ -130,17 +128,17 @@ let test_revdeps ~ocluster ~master ~base ~platform ~pkg ~after:main_build source
           Build.v ocluster ~label:"test" ~base ~spec ~master source
         in
         let+ label = Current.map OpamPackage.to_string revdep
-        and+ build = Node.of_job `Built image ~label:"build"
-        and+ tests = Node.of_job `Built tests ~label:"tests"
+        and+ build = Node.action `Built image
+        and+ tests = Node.action `Built tests
         and+ with_tests = with_tests
         in
         if with_tests then
-          Node.branch ~label [build; tests]
+          Node.actioned_branch ~label build [Node.leaf ~label:"tests" tests]
         else
-          Node.branch ~label [build]
+          Node.leaf ~label build
       )
   in
-  [Node.branch ~label:"revdeps" (list_op :: list_with_tests_op :: tests)]
+  [Node.branch ~label:"revdeps" tests]
 
 let build_with_cluster ~ocluster ~analysis ~master source =
   let pkgs = Current.map Analyse.Analysis.packages analysis in
@@ -168,20 +166,20 @@ let build_with_cluster ~ocluster ~analysis ~master source =
           Build.v ocluster ~label:"test" ~base ~spec ~master source
         in
         let+ pkg = pkg
-        and+ build = Node.of_job `Built image ~label:"build"
-        and+ tests = Node.of_job `Built tests ~label:"tests"
+        and+ build = Node.action `Built image
+        and+ tests = Node.action `Built tests
         and+ revdeps =
           if revdeps then test_revdeps ~ocluster ~master ~base ~platform ~pkg source ~after:image
           else Current.return []
         in
         let label = OpamPackage.to_string pkg in
-        Node.branch ~label (build :: tests :: revdeps)
+        Node.actioned_branch ~label build (Node.leaf ~label:"tests" tests :: revdeps)
       )
     |> Current.map (Node.branch ~label)
     |> Current.collapse ~key:"platform" ~value:label ~input:analysis
   in
   let build = build ~pool:"linux-x86_64" in
-  let+ analysis = Node.of_job `Checked analysis ~label:"(analysis)"
+  let+ analysis = Node.action `Checked analysis
   and+ compilers = Current.list_seq [
       build ~revdeps:true "4.12" "debian-10-ocaml-4.12";
       build ~revdeps:true "4.11" "debian-10-ocaml-4.11";
@@ -210,7 +208,7 @@ let build_with_cluster ~ocluster ~analysis ~master source =
     ]
   in
   Node.root [
-    analysis;
+    Node.leaf ~label:"(analysis)" analysis;
     Node.branch ~label:"compilers" compilers;
     Node.branch ~label:"distributions" distributions;
     Node.branch ~label:"extras" extras;


### PR DESCRIPTION
Here how the web-ui for PRs currently look:
![scrn-2020-11-04-17-21-51](https://user-images.githubusercontent.com/2611789/98144394-467cba00-1ec2-11eb-84f6-fc4f94737449.png)

With this change:
* `build (passing)` would merge with/become its parent (in the screenshot `sihl-email.0.1.7` and `sihl-queue.0.1.7`)
* the `list revdeps *` lines would disappear from the point of vue of the user.

This two change makes the web-ui should look much more user-friendly.