### PR TITLE
Add ocaml-system to the build matrix

### DIFF
--- a/lib/build.mli
+++ b/lib/build.mli
@@ -4,6 +4,7 @@ module Spec : sig
   val opam :
     ?revdep:OpamPackage.t ->
     platform:Platform.t ->
+    compiler:Platform.compiler ->
     with_tests:bool ->
     OpamPackage.t ->
     t
@@ -26,6 +27,7 @@ val list_revdeps :
   t ->
   with_tests:bool ->
   platform:Platform.t ->
+  compiler:Platform.compiler ->
   pkg:OpamPackage.t Current.t ->
   base:Current_docker.Raw.Image.t Current.t ->
   master:Current_git.Commit.t Current.t ->

--- a/lib/dune
+++ b/lib/dune
@@ -3,4 +3,4 @@
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
   (libraries logs current current_docker current_github current.term
              current.cache dockerfile ppx_deriving_yojson.runtime ocaml-version
-             current_ocluster capnp-rpc-lwt obuilder-spec opam-format))
+             current_ocluster capnp-rpc-lwt obuilder-spec opam-format dockerfile-opam))

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -41,14 +41,8 @@ let setup_repository ~variant ~compiler =
     | `Default | `Flambda ->
         []
   in
-  let opam_extras =
-    if Ocaml_version.compare compiler.Platform.compiler_version Ocaml_version.Releases.v4_08 < 0 then
-      [ run ~cache ~network "opam install -y ocaml-secondary-compiler" ] (* Speed up builds for dune >= 2.0 *)
-    else
-      []
-  in
   let distro_extras =
-    if Astring.String.is_prefix ~affix:"fedora" variant then
+    if Astring.String.is_prefix ~affix:"fedora" variant then (* TODO: Replace by match distro with `Fedora _ -> ... *)
       [ run ~network "sudo dnf install -y findutils" ] (* (we need xargs) *)
     else
       []
@@ -57,7 +51,7 @@ let setup_repository ~variant ~compiler =
   env "OPAMERRLOGLEN" "0" :: (* Show the whole log if it fails *)
   env "OPAMSOLVERTIMEOUT" "500" :: (* Increase timeout. Poor mccs is doing its best *)
   env "OPAMPRECISETRACKING" "1" :: (* Mitigate https://github.com/ocaml/opam/issues/3997 *)
-  user ~uid:1000 ~gid:1000 :: switch_setup @ distro_extras @ opam_extras @ [
+  user ~uid:1000 ~gid:1000 :: switch_setup @ distro_extras @ [
     copy ["."] ~dst:"/src/";
     run "opam repository set-url --strict default file:///src";
   ]

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -26,16 +26,16 @@ let setup_repository ~variant ~compiler =
   let switch_setup =
     match compiler.Platform.compiler_option with
     | `System ->
-        let maj_min_v = Ocaml_version.to_string compiler.Platform.compiler_version in
         let full_v = Ocaml_version.to_string compiler.Platform.compiler_full_version in
         [
-          run "curl -L http://caml.inria.fr/pub/distrib/ocaml-%s/ocaml-%s.tar.gz | tar -xzf - \
-               cd 'ocaml-%s' && \
+          run "opam source 'ocaml-base-compiler.%s' && \
+               cd 'ocaml-base-compiler.%s' && \
                ./configure -prefix /usr/local --with-debug-runtime && \
                make world.opt && \
                sudo make install && \
-               rm -rf 'ocaml-%s'"
-            maj_min_v full_v full_v full_v;
+               cd .. && \
+               rm -rf 'ocaml-base-compiler.%s'"
+            full_v full_v full_v;
           run "opam switch create ocaml-system";
         ]
     | `Default | `Flambda ->

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -2,6 +2,7 @@ val spec :
   base:string ->
   variant:string ->
   revdep:OpamPackage.t option ->
+  compiler:Platform.compiler ->
   with_tests:bool ->
   pkg:OpamPackage.t ->
   Obuilder_spec.stage
@@ -10,5 +11,6 @@ val revdeps :
   with_tests:bool ->
   base:string ->
   variant:string ->
+  compiler:Platform.compiler ->
   pkg:OpamPackage.t ->
   Obuilder_spec.stage

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -1,3 +1,18 @@
+type compiler_option = [
+  | `Default
+  | `Flambda
+  | `System
+] [@@deriving to_yojson]
+
+let ocaml_version_to_yojson v =
+  `String (Ocaml_version.to_string v)
+
+type compiler = {
+  compiler_version : Ocaml_version.t [@to_yojson ocaml_version_to_yojson];
+  compiler_full_version : Ocaml_version.t [@to_yojson ocaml_version_to_yojson];
+  compiler_option : compiler_option;
+} [@@deriving to_yojson]
+
 type t = {
   label : string;
   pool : string;        (* OCluster pool *)


### PR DESCRIPTION
This more or less mirrors the `INSTALL_LOCAL` feature from ocaml-ci-scripts (https://github.com/ocaml/ocaml-ci-scripts/blob/9cb3224392a8a0593e62e002747831ebc25edcf3/.travis-ocaml.sh#L230) added by @dra27 in https://github.com/ocaml/ocaml-ci-scripts/pull/202

I had to change quite a bit of code because the compiler version wasn't available where it is needed in the `Opam_build` module but I did my best to avoid changing too much for review purpose.