### PR TITLE
Check revdeps recursively

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -84,7 +84,7 @@ let revdeps ~with_tests ~base ~variant ~pkg =
       setup_repository ~variant
       @ [
         run "echo '@@@OUTPUT' && \
-             opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --depopts%s && \
+             opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --recursive --depopts%s && \
              echo '@@@OUTPUT'"
           pkg pkg with_tests
       ]


### PR DESCRIPTION
I've seen quite a few issues recently after merging `opam-file-format.2.1.1`. This version broke many packages not relying on it specifically but rather later down the line (module name clash, undefined modules in some specific cases, …)

To fix this issue checking all the revdeps recursively seems like the way to go. This will put more strain to the cluster however, so we might want to monitor this a bit more closely.