### PR TITLE
Give each revdep its own cache hint

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -146,6 +146,7 @@ module Op = struct
     let cache_hint =
       let pkg =
         match ty with
+        | `Opam (`Build { revdep = Some revdep; _ }, pkg) -> Printf.sprintf "%s-%s" (OpamPackage.to_string pkg) (OpamPackage.to_string revdep)
         | `Opam (`List_revdeps _, pkg)
         | `Opam (`Build _, pkg) -> OpamPackage.to_string pkg
       in


### PR DESCRIPTION
Otherwise we'll try to build them all on the same machine, which isn't useful for packages with thousands of revdeps.