### PR TITLE
add support for installing some tests using opam 2.1

### DIFF
--- a/lib/build.mli
+++ b/lib/build.mli
@@ -5,6 +5,7 @@ module Spec : sig
     ?revdep:OpamPackage.t ->
     platform:Platform.t ->
     with_tests:bool ->
+    upgrade_opam:bool ->
     OpamPackage.t ->
     t
 end

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -1,4 +1,5 @@
 val spec :
+  upgrade_opam:bool ->
   base:string ->
   variant:Variant.t ->
   revdep:OpamPackage.t option ->


### PR DESCRIPTION
The "extras" tests all now install using opam 2.1, as a smoketest for the beta branch.

Untested until I figure out local execution, hence a draft PR. (I won't have much time for the next few days, so feel free to take this over if anyone wants)