### PR TITLE
Improve linter: Include opam's linter

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,6 +38,7 @@
   (capnp-rpc-lwt (>= 0.8.0))
   (capnp-rpc-unix (>= 0.8.0))
   opam-repo-ci-api
+  (opam-state (>= 2.1.0~beta4))
   (opam-format (>= 2.1.0~beta4))
   (opam-file-format (>= 2.1.2))
   conf-libev

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -1,7 +1,7 @@
 open Lwt.Infix
 open Current.Syntax
 
-let pool = Current.Pool.create ~label:"analyse" 2
+let pool = Current.Pool.create ~label:"analyse" 20
 
 let ( >>!= ) = Lwt_result.bind
 let list_is_empty = function [] -> true | _::_ -> false

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,18 @@
 (library
   (name opam_repo_ci)
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
-  (libraries logs current current_docker current_github current.term
-             current.cache dockerfile ppx_deriving_yojson.runtime ocaml-version
-             current_ocluster capnp-rpc-lwt obuilder-spec opam-format))
+  (libraries
+    logs
+    current
+    current_docker
+    current_github
+    current.term
+    current.cache
+    dockerfile
+    ppx_deriving_yojson.runtime
+    ocaml-version
+    current_ocluster
+    capnp-rpc-lwt
+    obuilder-spec
+    opam-format
+    opam-state))

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -1,7 +1,7 @@
 open Lwt.Infix
 open Current.Syntax
 
-let pool = Current.Pool.create ~label:"lint" 2
+let pool = Current.Pool.create ~label:"lint" 20
 
 let ( // ) = Filename.concat
 let ( >>/= ) x f = x >>= fun x -> f (Result.get_ok x)

--- a/opam-repo-ci-service.opam
+++ b/opam-repo-ci-service.opam
@@ -25,6 +25,7 @@ depends: [
   "capnp-rpc-lwt" {>= "0.8.0"}
   "capnp-rpc-unix" {>= "0.8.0"}
   "opam-repo-ci-api"
+  "opam-state" {>= "2.1.0~beta4"}
   "opam-format" {>= "2.1.0~beta4"}
   "opam-file-format" {>= "2.1.2"}
   "conf-libev"


### PR DESCRIPTION
This calls functions from the `opam-state` library equivalent to a call of `opam lint`.
As is this change makes this linter already better than Camelus since Camelus does not include warning 53 (extra-files check)