### PR TITLE
Add nnpchecker to the pipeline

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -152,15 +152,23 @@ module Op = struct
     Current.Job.log job "Using cache hint %S" cache_hint;
     Current.Job.log job "Using OBuilder spec:@.%s@." spec_str;
     let build_pool = Current_ocluster.Connection.pool ~job ~pool ~action ~cache_hint ~src connection in
+    let is_nnpchecker = Option.equal String.equal variant.Variant.ocaml_variant (Some "nnpchecker") in
     let buffer =
       match ty with
       | `Opam (`List_revdeps, _) -> Some (Buffer.create 1024)
+      | _ when is_nnpchecker -> Some (Buffer.create 50_000)
       | _ -> None
     in
     Current.Job.start_with ~pool:build_pool job ~timeout ~level:Current.Level.Average >>= fun build_job ->
     Capability.with_ref build_job (run_job ?buffer ~job) >>!= fun (_ : string) ->
     match buffer with
     | None -> Lwt_result.return ""
+    | Some buffer when is_nnpchecker ->
+        (* TODO: Remove this hack when we switch to OCaml 4.13. See https://github.com/ocaml/ocaml/pull/10171 *)
+        begin match Astring.String.find_sub ~rev:true ~sub:"Out-of-heap pointer at " (Buffer.contents buffer) with
+        | None -> Lwt_result.return ""
+        | Some _ -> Lwt_result.fail (`Msg "Naked pointers detected")
+        end
     | Some buffer ->
       match Astring.String.cuts ~sep:"\n@@@OUTPUT\n" (Buffer.contents buffer) with
       | [_; output; _] -> Lwt_result.return output
@@ -192,7 +200,7 @@ let v t ~label ~spec ~base ~master commit =
   let t = { Op.config = t; master } in
   let { Platform.pool; variant; label = _ } = platform in
   BC.run t { Op.Key.pool; commit; variant; ty } { Op.Value.base }
-  |> Current.Primitive.map_result (Result.map ignore)
+  |> Current.Primitive.map_result (Result.map ignore) (* TODO: Create a separate type of cache that doesn't parse the output *)
 
 let list_revdeps t ~platform ~pkg ~base ~master commit =
   Current.component "list revdeps" |>

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -194,8 +194,10 @@ let build_with_cluster ~ocluster ~analysis ~lint ~master source =
     let master_distro = Dockerfile_distro.tag_of_distro master_distro in
     let default_compiler = Ocaml_version.to_string default_compiler in
     let flambda = Variant.v ~arch:`X86_64 ~distro:master_distro ~compiler:(default_compiler, Some "flambda") in
+    let nnpchecker = Variant.v ~arch:`X86_64 ~distro:master_distro ~compiler:(default_compiler, Some "nnpchecker") in
     Current.list_seq (
       build ~upgrade_opam:true ~revdeps:false "flambda" flambda ::
+      build ~upgrade_opam:true ~revdeps:false "nnpchecker" nnpchecker ::
       List.fold_left (fun acc arch ->
         if arch = `X86_64 then
           acc


### PR DESCRIPTION
Rely on:
- [x] https://github.com/ocurrent/ocaml-version/pull/28
- [x] its inclusion into `docker-base-images`
- [x] `+nnpchecker` images being available on Docker Hub