### PR TITLE
Do not count the the list_revdeps job as a "real job"

### DIFF
--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -111,7 +111,7 @@ let test_revdeps ~ocluster ~master ~base ~platform ~pkg ~after:main_build source
         in
         Node.leaf ~label build
       )
-  and+ list_revdeps = Node.action `Built revdeps
+  and+ list_revdeps = Node.action `Analysed revdeps
   in
   [Node.actioned_branch ~label:"revdeps" list_revdeps tests]
 


### PR DESCRIPTION
This makes https://github.com/ocaml/opam-repository/pull/18395 when it should not (no successful build)