### PR TITLE
Enable the opam sandbox

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -56,7 +56,6 @@ let setup_repository ~for_docker ~upgrade_opam =
   env "OPAMSOLVERTIMEOUT" "500" :: (* Increase timeout. Poor mccs is doing its best *)
   env "OPAMPRECISETRACKING" "1" :: (* Mitigate https://github.com/ocaml/opam/issues/3997 *)
   [
-    user ~uid:1000 ~gid:1000;
     copy ["."] ~dst:"/src/";
     run "opam repository set-url --strict default file:///src";
   ]
@@ -80,6 +79,7 @@ let spec ~for_docker ~upgrade_opam ~base ~variant ~revdep ~with_tests ~pkg =
   { from = base;
     ops =
       set_personality ~variant
+      @ [user ~uid:1000 ~gid:1000]
       @ setup_repository ~for_docker ~upgrade_opam
       @ opam_install ~variant ~upgrade_opam ~pin:true ~with_tests:false ~pkg
       @ revdep

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -1,4 +1,5 @@
 val spec :
+  for_docker:bool ->
   upgrade_opam:bool ->
   base:string ->
   variant:Variant.t ->
@@ -8,6 +9,7 @@ val spec :
   Obuilder_spec.stage
 
 val revdeps :
+  for_docker:bool ->
   base:string ->
   variant:Variant.t ->
   pkg:OpamPackage.t ->


### PR DESCRIPTION
obuilder supports bubblewrap as opposed to docker, so the technical reason why we were disabling the opam sandbox doesn't hold anymore in our particular context :tada: