### PR TITLE
Do not make the linter rebuild on every change in master

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -248,9 +248,8 @@ module Lint = struct
       master : Current_git.Commit.t;
     }
 
-    let digest { master } =
+    let digest { master = _ } =
       let json = `Assoc [
-          "master", `String (Current_git.Commit.hash master);
         ]
       in
       Yojson.Safe.to_string json


### PR DESCRIPTION
Rational: the number of merges in opam-repository is rather high and I always end up looking at logs and not seeing the linter failure because it is being rebuilt (btw is there any ways in ocurrent(_web?) to never show when a job is being rebuilt @talex5 ?)