### PR TITLE
[Proposal 1/2] Only trigger revdeps on critical changes

### DIFF
--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -2,6 +2,7 @@ module Analysis : sig
   type kind =
     | New
     | Deleted
+    | CriticallyChanged
     | SignificantlyChanged
     | UnsignificantlyChanged
   [@@deriving yojson]

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -169,7 +169,7 @@ module Check = struct
       match kind with
       | Analyse.Analysis.Deleted ->
           Lwt.return errors (* TODO *)
-      | Analyse.Analysis.(New | SignificantlyChanged | UnsignificantlyChanged) ->
+      | Analyse.Analysis.(New | CriticallyChanged | SignificantlyChanged | UnsignificantlyChanged) ->
           get_opam ~cwd pkg >>= fun opam ->
           (* Check name field *)
           let errors = match OpamFile.OPAM.name_opt opam with


### PR DESCRIPTION
The revdeps checker comes with a high cost to the cluster, especially when modifying key packages, it can easily induce half a day-long (on the good days) delays for other services using the cluster.

I have personally several big PRs coming up to fix lower-bounds constraints of several key packages and I don't want to make the cluster struggle for nothing (on these kind of PRs, the revdeps checker is extremely rarely useful, i personally can't remember a single instance where it was)

This PR is one of two alternative changes to opam-repo-ci to tackle this issue (the second one is coming up in a minute)

This PR tries to identify changes where the revdeps checker might be useful – namely when one of the field changing what is built or installed is changed (`build:`, `install:`, `patches:`, …) – and automatically disables the revdeps checker if it is not in this case.