### PR TITLE
Various improvements

### DIFF
--- a/lib/index.ml
+++ b/lib/index.ml
@@ -77,10 +77,12 @@ let init () = ignore (Lazy.force db)
 
 let get_job_ids t ~owner ~name ~hash =
   Db.query t.get_job_ids Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash ]
-  |> List.map @@ function
+  |> List.rev_map begin function
   | Sqlite3.Data.[ TEXT variant; NULL ] -> variant, None
   | Sqlite3.Data.[ TEXT variant; TEXT id ] -> variant, Some id
   | row -> Fmt.failwith "get_job_ids: invalid row %a" Db.dump_row row
+  end
+  |> List.rev
 
 module Status_cache = struct
   let cache = Hashtbl.create 1_000

--- a/service/main.ml
+++ b/service/main.ml
@@ -2,6 +2,8 @@ open Capnp_rpc_lwt
 open Lwt.Infix
 
 let () =
+  Printexc.record_backtrace true;
+  Printexc.register_printer (fun e -> Some (Printexc.to_string_default e ^ " -- " ^ Printexc.get_backtrace ()));
   Memtrace.trace_if_requested ~context:"opam-repo-ci" ();
   Unix.putenv "DOCKER_BUILDKIT" "1";
   Prometheus_unix.Logging.init ();


### PR DESCRIPTION
Extracted from #108 and its debugging phase.

The reasoning behind always recording and printing the backtrace is that uncaught exceptions inside of opam-repo-ci will almost always be bugs and only having their name isn't very helpful without the backtrace (e.g. for stack overflows)