### PR TITLE
Set the revdeps jobs as non-urgent on modified packages

### DIFF
--- a/lib/build.mli
+++ b/lib/build.mli
@@ -21,13 +21,14 @@ val v :
   spec:Spec.t Current.t ->
   base:Current_docker.Raw.Image.t Current.t ->
   master:Current_git.Commit.t Current.t ->
+  urgent:([`High | `Low] -> bool) option Current.t ->
   Current_git.Commit_id.t Current.t ->
   unit Current.t
 
 val list_revdeps :
   t ->
   platform:Platform.t ->
-  pkg:OpamPackage.t Current.t ->
+  pkgopt:PackageOpt.t Current.t ->
   base:Current_docker.Raw.Image.t Current.t ->
   master:Current_git.Commit.t Current.t ->
   Current_git.Commit_id.t Current.t ->

--- a/lib/packageOpt.ml
+++ b/lib/packageOpt.ml
@@ -1,0 +1,10 @@
+type t = {
+  pkg : OpamPackage.t;
+  urgent : ([`High | `Low] -> bool) option;
+}
+
+let compare {pkg = pkg1; urgent = _} {pkg = pkg2; urgent = _} =
+  OpamPackage.compare pkg1 pkg2
+
+let pp f {pkg; urgent = _} =
+  Fmt.of_to_string OpamPackage.to_string f pkg


### PR DESCRIPTION
Discussed at the last meeting as a replacement for #107 and #108.

This prioritizes truly important jobs: any jobs but the revdeps of modified packages