### PR TITLE
Make the version of opam used explicit in prevision for the upgrade of the base docker images

### DIFF
--- a/lib/build.mli
+++ b/lib/build.mli
@@ -6,7 +6,7 @@ module Spec : sig
     platform:Platform.t ->
     lower_bounds:bool ->
     with_tests:bool ->
-    upgrade_opam:bool ->
+    opam_version:[`V2_0 | `V2_1] ->
     OpamPackage.t ->
     t
 end

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -1,6 +1,6 @@
 val spec :
   for_docker:bool ->
-  upgrade_opam:bool ->
+  opam_version:[`V2_0 | `V2_1] ->
   base:string ->
   variant:Variant.t ->
   revdep:OpamPackage.t option ->


### PR DESCRIPTION
This way we don't have to change the code for opam 2.2 or if the docker images upgrade to opam 2.1 by default.

However this changes the key of the ocurrent cache and will restart all the builds. **To merge when we have a low number of small PRs.**