### PR TITLE
Fail meaningfully when a PR contains an opam file with a syntax error

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -148,11 +148,14 @@ module Analysis = struct
                     let filename = OpamFile.make (OpamFilename.raw path) in
                     let old_file =
                       try OpamFile.OPAM.read_from_string ~filename old_content
-                      with Failure _ -> OpamFile.OPAM.empty
+                      with OpamPp.Bad_format _ | OpamPp.Bad_version _ -> OpamFile.OPAM.empty
                     in
                     let new_file =
                       try OpamFile.OPAM.read_from_string ~filename new_content
-                      with Failure msg -> Fmt.failwith "%S failed to be parsed: %s" path msg
+                      with
+                      | OpamPp.Bad_format (_, msg)
+                      | OpamPp.Bad_version (_, msg) ->
+                          Fmt.failwith "%S failed to be parsed: %s" path msg
                     in
                     check_opam new_file;
                     if OpamFile.OPAM.effectively_equal old_file new_file &&


### PR DESCRIPTION
The parse failure wasn't correctly caught and so, e.g. @dinosaure got:
```
2021-10-04 14:23.05: Job failed: OpamPp.Bad_format(_) -- Raised by primitive operation at Lwt_unix.read_bigarray.(fun) in file "src/unix/lwt_unix.cppo.ml", line 681, characters 8-59
Called from Lwt_unix.wrap_syscall.(fun) in file "src/unix/lwt_unix.cppo.ml", line 562, characters 17-28
```
in https://github.com/ocaml/opam-repository/commit/1d4295b64bfbd992ae016256b453015a5c31a9c4