### PR TITLE
Test revdeps that cannot be tested on the latest version of the compiler

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -207,6 +207,11 @@ let v t ~label ~spec ~base ~master ~urgent commit =
   BC.run t { Op.Key.pool; commit; variant; ty } ()
   |> Current.Primitive.map_result (Result.map ignore) (* TODO: Create a separate type of cache that doesn't parse the output *)
 
+type revdep = {
+  base_pkg : OpamPackage.t;
+  revdep : OpamPackage.t;
+}
+
 let list_revdeps t ~platform ~pkgopt ~base ~master commit =
   Current.component "list revdeps" |>
   let> {PackageOpt.pkg; urgent} = pkgopt
@@ -226,6 +231,6 @@ let list_revdeps t ~platform ~pkgopt ~base ~master commit =
               if OpamPackage.equal pkg revdep then
                 None (* NOTE: opam list --recursive --depends-on <pkg> also returns <pkg> itself *)
               else
-                Some revdep
+                Some {base_pkg = pkg; revdep}
         )
     ))

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -25,6 +25,11 @@ val v :
   Current_git.Commit_id.t Current.t ->
   unit Current.t
 
+type revdep = {
+  base_pkg : OpamPackage.t;
+  revdep : OpamPackage.t;
+}
+
 val list_revdeps :
   t ->
   platform:Platform.t ->
@@ -32,4 +37,4 @@ val list_revdeps :
   base:Current_docker.Raw.Image.t Current.t ->
   master:Current_git.Commit.t Current.t ->
   Current_git.Commit_id.t Current.t ->
-  OpamPackage.t list Current.t
+  revdep list Current.t


### PR DESCRIPTION
Currently only revdeps on 4.12 are being tested to avoid an explosion of the cluster, however some people still use older versions of the compiler (e.g. https://github.com/ocaml/opam-repository/pull/19837).
To avoid this issue in the future, this PR makes the CI test every packages on every versions but removes the ones that are already being tested (in order from the latest compiler to the oldest) so the number of jobs given to the cluster is more manageable.

I suspect this will still be a bit heavy on the cluster but much more managable with this trick.