### PR TITLE
Install CI certificate in the web image

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -13,7 +13,7 @@ ADD --chown=opam . .
 RUN opam config exec -- dune build ./_build/install/default/bin/opam-repo-ci-web
 
 FROM debian:11
-RUN apt-get update && apt-get install libev4 dumb-init -y --no-install-recommends
+RUN apt-get update && apt-get install ca-certificates libev4 dumb-init -y --no-install-recommends
 WORKDIR /
 ENTRYPOINT ["dumb-init", "/usr/local/bin/opam-repo-ci-web"]
 COPY --from=build /src/_build/install/default/bin/opam-repo-ci-web /usr/local/bin/


### PR DESCRIPTION
Otherwise we get:
```
Fatal error: exception (Failure
   "ca-certs: no trust anchor file found, looked into /etc/ssl/certs/ca-certificates.crt, /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.
```
I’m not sure why this changed but oh well.. at least it’s working now.