### PR TITLE
Make the cluster distribution fairer

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -151,7 +151,7 @@ module Op = struct
         | `Opam (`List_revdeps, pkg)
         | `Opam (`Build _, pkg) -> OpamPackage.to_string pkg
       in
-      Printf.sprintf "%s-%s" (Image.hash base) pkg
+      Printf.sprintf "%s-%s-%s" (Image.hash base) pkg (Git.Commit_id.hash commit)
     in
     Current.Job.log job "Using cache hint %S" cache_hint;
     Current.Job.log job "Using OBuilder spec:@.%s@." spec_str;


### PR DESCRIPTION
The previous cache hint wasn’t too good. It always chose one server on the cluster when building one package on a given distribution. For example this causes problems when adding more builders (e.g. macos) as none of the build get passed over to the new builder.