### PR TITLE
Fix crashes in compilers heavy PRs

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -211,13 +211,13 @@ let list_revdeps t ~platform ~pkgopt ~base ~master commit =
   BC.run t { Op.Key.pool; commit; variant; ty } ()
   |> Current.Primitive.map_result (Result.map (fun output ->
       String.split_on_char '\n' output |>
-      List.filter_map (function
-          | "" -> None
+      List.fold_left (fun acc -> function
+          | "" -> acc
           | revdep ->
               let revdep = OpamPackage.of_string revdep in
               if OpamPackage.equal pkg revdep then
-                None (* NOTE: opam list --recursive --depends-on <pkg> also returns <pkg> itself *)
+                acc (* NOTE: opam list --recursive --depends-on <pkg> also returns <pkg> itself *)
               else
-                Some revdep
-        )
+                OpamPackage.Set.add revdep acc
+        ) OpamPackage.Set.empty
     ))

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -199,12 +199,13 @@ let v t ~label ~spec ~base ~master ~urgent commit =
   BC.run t { Op.Key.pool; commit; variant; ty } ()
   |> Current.Primitive.map_result (Result.map ignore) (* TODO: Create a separate type of cache that doesn't parse the output *)
 
-let list_revdeps t ~platform ~pkgopt ~base ~master commit =
+let list_revdeps t ~platform ~pkgopt ~base ~master ~after commit =
   Current.component "list revdeps" |>
   let> {PackageOpt.pkg; urgent} = pkgopt
   and> base = base
   and> commit = commit
-  and> master = master in
+  and> master = master
+  and> () = after in
   let t = { Op.config = t; master; urgent; base } in
   let { Platform.pool; variant; label = _ } = platform in
   let ty = `Opam (`List_revdeps, pkg) in

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -32,4 +32,4 @@ val list_revdeps :
   base:Current_docker.Raw.Image.t Current.t ->
   master:Current_git.Commit.t Current.t ->
   Current_git.Commit_id.t Current.t ->
-  OpamPackage.t list Current.t
+  OpamPackage.Set.t Current.t

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -31,5 +31,6 @@ val list_revdeps :
   pkgopt:PackageOpt.t Current.t ->
   base:Current_docker.Raw.Image.t Current.t ->
   master:Current_git.Commit.t Current.t ->
+  after:unit Current.t ->
   Current_git.Commit_id.t Current.t ->
   OpamPackage.Set.t Current.t

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -45,6 +45,11 @@ let opam_install ~variant ~opam_version ~pin ~lower_bounds ~with_tests ~pkg =
 let setup_repository ~variant ~for_docker ~opam_version =
   let open Obuilder_spec in
   user ~uid:1000 ~gid:1000 ::
+  run "for pkg in $(opam pin list --short); do opam pin remove \"$pkg\"; done" :: (* The ocaml/opam base images have a pin to their compiler package.
+                                                                                     Such pin is useless for opam 2.0 as we don't use --unlock-base,
+                                                                                     and causes issues for opam 2.1 as it allows to upgrade the compiler
+                                                                                     package (not what we want)
+                                                                                     See: https://github.com/ocaml/opam/issues/4501 *)
   run "opam repository remove -a multicore || true" :: (* We remove this non-standard repository
                                                           because we don't have access and it hosts
                                                           non-official packages *)

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -90,17 +90,10 @@ let revdep_spec ~platform ~opam_version ~revdep pkg =
   in
   Build.Spec.opam ~platform ~lower_bounds:false ~with_tests:true ~revdep ~opam_version pkg
 
-let combine_revdeps revdeps =
-  let map =
-    List.fold_left (fun set pkg -> OpamPackage.Set.add pkg set) OpamPackage.Set.empty revdeps
-  in
-  OpamPackage.Set.elements map
-
 (* List the revdeps of [pkg] (using [builder] and [image]) and test each one
    (using [spec] and [base], merging [source] into [master]). *)
 let test_revdeps ~ocluster ~opam_version ~master ~base ~platform ~pkgopt ~after:main_build source =
-  let revdeps = Build.list_revdeps ~base ocluster ~platform ~pkgopt ~master source in
-  let revdeps = Current.map combine_revdeps revdeps in
+  let revdeps = Current.map OpamPackage.Set.elements revdeps in
   let pkg = Current.map (fun {PackageOpt.pkg = pkg; urgent = _} -> pkg) pkgopt in
   let urgent = Current.map (fun {PackageOpt.pkg = _; urgent} -> urgent) pkgopt in
   let+ tests =

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -92,13 +92,15 @@ let revdep_spec ~platform ~opam_version ~revdep pkg =
 
 (* List the revdeps of [pkg] (using [builder] and [image]) and test each one
    (using [spec] and [base], merging [source] into [master]). *)
-let test_revdeps ~ocluster ~opam_version ~master ~base ~platform ~pkgopt ~after:main_build source =
-  let revdeps = Current.map OpamPackage.Set.elements revdeps in
+let test_revdeps ~ocluster ~opam_version ~master ~base ~platform ~pkgopt ~after source =
+  let revdeps =
+    Build.list_revdeps ~base ocluster ~platform ~pkgopt ~master ~after source |>
+    Current.map OpamPackage.Set.elements
+  in
   let pkg = Current.map (fun {PackageOpt.pkg = pkg; urgent = _} -> pkg) pkgopt in
   let urgent = Current.map (fun {PackageOpt.pkg = _; urgent} -> urgent) pkgopt in
   let+ tests =
     revdeps
-    |> Current.gate ~on:main_build
     |> dep_list_map (module OpamPackage) (fun revdep ->
         let image =
           let spec = revdep_spec ~platform ~opam_version ~revdep pkg in


### PR DESCRIPTION
Just a hunch on why https://github.com/ocaml/opam-repository/pull/19855 might make the CI crash.
In any case this is an obvious improvement