### PR TITLE
Avoid spending time converting lists into Index.Job_map

### DIFF
--- a/lib/index.mli
+++ b/lib/index.mli
@@ -10,11 +10,13 @@ type build_status = [ `Not_started | `Pending | `Failed | `Passed ]
 val init : unit -> unit
 (** Ensure the database is initialised (for unit-tests). *)
 
+module Job_map : module type of Astring.String.Map
+
 val record :
   repo:Current_github.Repo_id.t ->
   hash:string ->
   status:build_status ->
-  (string * Current.job_id option) list ->
+  Current.job_id option Job_map.t ->
   unit
 (** [record ~repo ~hash jobs] updates the entry for [repo, hash] to point at [jobs]. *)
 

--- a/service/node.mli
+++ b/service/node.mli
@@ -1,3 +1,5 @@
+open Opam_repo_ci
+
 type action
 (** A result *)
 
@@ -24,10 +26,9 @@ val action : [ `Built | `Analysed | `Linted ] -> _ Current.t -> action Current.t
     is always successful and immediately available. *)
 
 val flatten :
-  (label:string ->
-   job_id:string option ->
+  (job_id:string option ->
    result:[ `Built | `Analysed | `Linted ] Current_term.Output.t -> 'a) ->
-  t -> 'a list
+  t -> 'a Index.Job_map.t
 (** [flatten f t] converts the tree to a list, applying [f] to each element. *)
 
 val dump : t Fmt.t

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -14,17 +14,17 @@ let test_simple () =
   Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
                                      VALUES ('test', x'00', 'job1', x'01', 1, x'02', '2019-11-01 9:00', '2019-11-01 9:01', '2019-11-01 9:02', 0)";
   Index.set_active_refs ~repo ["master", hash];
-  Index.record ~repo ~hash ~status:`Pending [ "analysis", Some "job1";
+  Index.record ~repo ~hash ~status:`Pending @@ Index.Job_map.of_list [ "analysis", Some "job1";
                              "alpine", None ];
   Alcotest.(check (list string)) "Repos" ["name"] @@ Index.list_repos owner;
   Alcotest.(check (list (pair string string))) "Refs" ["master", hash] @@ Index.get_active_refs repo;
   Alcotest.(check jobs) "Jobs" ["alpine", `Not_started; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
   Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
                                      VALUES ('test', x'01', 'job2', x'01', 0, x'21', '2019-11-01 9:03', '2019-11-01 9:04', '2019-11-01 9:05', 0)";
-  Index.record ~repo ~hash ~status:`Failed [ "analysis", Some "job1";
+  Index.record ~repo ~hash ~status:`Failed @@ Index.Job_map.of_list [ "analysis", Some "job1";
                              "alpine", Some "job2" ];
   Alcotest.(check jobs) "Jobs" ["alpine", `Failed "!"; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
-  Index.record ~repo ~hash ~status:`Passed [ "analysis", Some "job1" ];
+  Index.record ~repo ~hash ~status:`Passed @@ Index.Job_map.of_list [ "analysis", Some "job1" ];
   Alcotest.(check jobs) "Jobs" ["analysis", `Passed] @@ Index.get_jobs ~owner ~name hash
 
 let tests = [


### PR DESCRIPTION
Directly transform `Node.t` into `Index.Job_map` instead.

According to the quick duration memtrace done today, a lot of data is being held by `Node.t`, however to get the data out of it we current:
* first transform the whole tree into lists
* flatten them
* then convert them into a map (which also sometimes went through `List.rev` for no reason)

Transforming the tree into a map is much more effeciant.