### PR TITLE
Build the list of packages to test with both opam 2.0 and 2.1

### DIFF
--- a/lib/build.mli
+++ b/lib/build.mli
@@ -28,6 +28,7 @@ val v :
 val list_revdeps :
   t ->
   platform:Platform.t ->
+  opam_version:[`V2_0 | `V2_1] ->
   pkgopt:PackageOpt.t Current.t ->
   base:Current_docker.Raw.Image.t Current.t ->
   master:Current_git.Commit.t Current.t ->

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -105,12 +105,11 @@ let spec ~for_docker ~opam_version ~base ~variant ~revdep ~lower_bounds ~with_te
     @ tests
   )
 
-let revdeps ~for_docker ~base ~variant ~pkg =
+let revdeps ~for_docker ~opam_version ~base ~variant ~pkg =
   let open Obuilder_spec in
   let pkg = Filename.quote (OpamPackage.to_string pkg) in
   Obuilder_spec.stage ~from:base (
-    (* TODO: Switch to opam 2.1 when https://github.com/ocaml/opam/issues/4311 is fixed *)
-    setup_repository ~variant ~for_docker ~opam_version:`V2_0
+    setup_repository ~variant ~for_docker ~opam_version
     @ [
       run "echo '@@@OUTPUT' && \
            opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --recursive --depopts && \

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -11,6 +11,7 @@ val spec :
 
 val revdeps :
   for_docker:bool ->
+  opam_version:[`V2_0 | `V2_1] ->
   base:string ->
   variant:Variant.t ->
   pkg:OpamPackage.t ->

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -94,7 +94,7 @@ let revdep_spec ~platform ~opam_version ~revdep pkg =
    (using [spec] and [base], merging [source] into [master]). *)
 let test_revdeps ~ocluster ~opam_version ~master ~base ~platform ~pkgopt ~after source =
   let revdeps =
-    Build.list_revdeps ~base ocluster ~platform ~pkgopt ~master ~after source |>
+    Build.list_revdeps ~base ocluster ~platform ~opam_version ~pkgopt ~master ~after source |>
     Current.map OpamPackage.Set.elements
   in
   let pkg = Current.map (fun {PackageOpt.pkg = pkg; urgent = _} -> pkg) pkgopt in


### PR DESCRIPTION
opam 2.1 is taking way too long to run opam list twice at the moment but 2.1.3 should be able to fix this issue.

This would fixes issues where e.g. mirage 4.0.0~beta3 is not tested in the revdeps because `opam list --depends-on` is only ran with opam 2.0