### PR TITLE
Fix production after #154

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -7,12 +7,12 @@ secrets:
     external: true
   opam-repo-ci-oauth:
     external: true
-  ocaml-ci-webhook-secret:
+  opam-repo-ci-webhook-secret:
     external: true
 services:
   ci:
     image: opam-repo-ci-service
-    command: --github-app-id 52344 --github-private-key-file /run/secrets/opam-repo-ci-github-key --github-account-whitelist "kit-ty-kate" --confirm above-average --confirm-auto-release 120 --capnp-address=tcp:ci:9000 --github-oauth /run/secrets/opam-repo-ci-oauth --github-webhook-secret-file /run/secrets/ocaml-ci-webhook-secret
+    command: --github-app-id 52344 --github-private-key-file /run/secrets/opam-repo-ci-github-key --github-account-whitelist "kit-ty-kate" --confirm above-average --confirm-auto-release 120 --capnp-address=tcp:ci:9000 --github-oauth /run/secrets/opam-repo-ci-oauth --github-webhook-secret-file /run/secrets/opam-repo-ci-webhook-secret
     environment:
       - "CI_PROFILE=production"
       - "PROGRESS_NO_TRUNC=1"
@@ -25,7 +25,7 @@ services:
     secrets:
       - 'opam-repo-ci-oauth'
       - 'opam-repo-ci-github-key'
-      - 'ocaml-ci-webhook-secret'
+      - 'opam-repo-ci-webhook-secret'
     sysctls:
       - 'net.ipv4.tcp_keepalive_time=60'
     networks:

--- a/stack.yml
+++ b/stack.yml
@@ -7,10 +7,12 @@ secrets:
     external: true
   opam-repo-ci-oauth:
     external: true
+  ocaml-ci-webhook-secret:
+    external: true
 services:
   ci:
     image: opam-repo-ci-service
-    command: --github-app-id 52344 --github-private-key-file /run/secrets/opam-repo-ci-github-key --github-account-whitelist "kit-ty-kate" --confirm above-average --confirm-auto-release 120 --capnp-address=tcp:ci:9000 --github-oauth /run/secrets/opam-repo-ci-oauth
+    command: --github-app-id 52344 --github-private-key-file /run/secrets/opam-repo-ci-github-key --github-account-whitelist "kit-ty-kate" --confirm above-average --confirm-auto-release 120 --capnp-address=tcp:ci:9000 --github-oauth /run/secrets/opam-repo-ci-oauth --github-webhook-secret-file /run/secrets/ocaml-ci-webhook-secret
     environment:
       - "CI_PROFILE=production"
       - "PROGRESS_NO_TRUNC=1"
@@ -23,6 +25,7 @@ services:
     secrets:
       - 'opam-repo-ci-oauth'
       - 'opam-repo-ci-github-key'
+      - 'ocaml-ci-webhook-secret'
     sysctls:
       - 'net.ipv4.tcp_keepalive_time=60'
     networks:


### PR DESCRIPTION
Requires this new `ocaml-ci-webhook-secret` file.
cc @tmcgilchrist 