### PR TITLE
Alternative Node representation to reduce memory load

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -164,12 +164,12 @@ module Op = struct
     Current.Job.log job "Using cache hint %S" cache_hint;
     Current.Job.log job "Using OBuilder spec:@.%s@." spec_str;
     let build_pool = Current_ocluster.Connection.pool ?urgent ~job ~pool ~action ~cache_hint ~src connection in
+    Current.Job.start_with ~pool:build_pool job ~timeout ~level:Current.Level.Average >>= fun build_job ->
     let buffer =
       match ty with
       | `Opam (`List_revdeps, _) -> Some (Buffer.create 1024)
       | _ -> None
     in
-    Current.Job.start_with ~pool:build_pool job ~timeout ~level:Current.Level.Average >>= fun build_job ->
     Capability.with_ref build_job (run_job ?buffer ~job) >>!= fun (_ : string) ->
     match buffer with
     | None -> Lwt_result.return ""

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -5,6 +5,8 @@ module Db = Current.Db
 
 module Job_map = Astring.String.Map
 
+type job_ids = Current.job_id option Job_map.t
+
 type t = {
   record_job : Sqlite3.stmt;
   remove : Sqlite3.stmt;
@@ -105,10 +107,12 @@ end
 
 let get_status = Status_cache.find
 
-let record ~repo ~hash ~status jobs =
+let set_status ~owner ~name ~hash status =
+  Status_cache.add ~owner ~name ~hash status
+
+let record ~repo ~hash jobs =
   let { Current_github.Repo_id.owner; name } = repo in
   let t = Lazy.force db in
-  let () = Status_cache.add ~owner ~name ~hash status in
   let previous = get_job_ids_with_variant t ~owner ~name ~hash in
   let merge variant prev job =
     let set job_id =

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -12,11 +12,12 @@ val init : unit -> unit
 
 module Job_map : module type of Astring.String.Map
 
+type job_ids = Current.job_id option Job_map.t
+
 val record :
   repo:Current_github.Repo_id.t ->
   hash:string ->
-  status:build_status ->
-  Current.job_id option Job_map.t ->
+  job_ids ->
   unit
 (** [record ~repo ~hash jobs] updates the entry for [repo, hash] to point at [jobs]. *)
 
@@ -40,6 +41,14 @@ val get_status:
   hash:string ->
   build_status
 (** [get_status ~owner ~name ~hash] is the latest status for this combination. *)
+
+val set_status:
+  owner:string ->
+  name:string ->
+  hash:string ->
+  build_status ->
+  unit
+(** [set_status ~owner ~name ~hash build_status] sets the latest status for this combination. *)
 
 val get_full_hash : owner:string -> name:string -> string -> (string, [> `Ambiguous | `Unknown | `Invalid]) result
 (** [get_full_hash ~owner ~name short_hash] returns the full hash for [short_hash]. *)

--- a/service/node.ml
+++ b/service/node.ml
@@ -1,66 +1,96 @@
 open Current.Syntax
-open Opam_repo_ci
 
-type action = {
-  job_id : Current.job_id option;
-  result : [`Built | `Analysed | `Linted] Current_term.Output.t;
+type kind = [`Built | `Analysed | `Linted]
+
+type 'a f = { f : 'x . label: string Current.t -> kind -> 'x Current.t -> 'a Current.t }
+
+type 'a ctx = {
+  label : string Current.t;
+  map : 'a f;
+  merge : 'a -> 'a -> 'a;
+  empty : 'a;
 }
 
-type t =
-  | Root of t list
-  | Branch of { label : string; action : action option; children : t list }
+type 'a t = ctx: 'a ctx -> 'a Current.t
 
 let status_sep = String.make 1 Opam_repo_ci_api.Common.status_sep
+
+let flatten t ~map ~merge ~empty =
+  let ctx = { label = Current.return "" ; map ; merge ; empty } in
+  t ~ctx
+
+
+let empty ~ctx = Current.return ctx.empty
+
+let action kind job ~ctx = ctx.map.f ~label:ctx.label kind job
+
+let leaf ~label t ~ctx =
+  t ~ctx: { ctx with label = let+ prefix = ctx.label in prefix ^ label }
+
+let leaf_dyn ~label t ~ctx =
+  t ~ctx: { ctx with label = let+ prefix = ctx.label and+ label = label in prefix ^ label }
+
+let dir ~label = leaf ~label:(label ^ status_sep)
+
+let dir_dyn ~label t ~ctx =
+  t ~ctx: { ctx with label = let+ prefix = ctx.label and+ label = label in prefix ^ label ^ status_sep }
+
+
+let of_list children ~ctx =
+  List.fold_left
+    (fun acc t ->
+      let+ acc = acc
+      and+ t = t ~ctx
+      in ctx.merge acc t)
+    (empty ~ctx)
+    children
+
+let root = of_list
+
+let branch ~label children = dir ~label (of_list children)
+
+let branch_dyn ~label children = dir_dyn ~label (of_list children)
+
+let actioned_branch (type a) ~label (action : a t) children ~ctx =
+  let+ t = leaf ~label action ~ctx
+  and+ ts = dir ~label (of_list children) ~ctx
+  in ctx.merge t ts
+
+let actioned_branch_dyn ~label action children ~ctx =
+  let+ t = leaf_dyn ~label action ~ctx
+  and+ ts = dir_dyn ~label (of_list children) ~ctx
+  in ctx.merge t ts
+
+
+let map_reduce ordered ?collapse_key ~map ~merge ~empty input =
+  let+ lst = Current.list_map ordered ?collapse_key map input in
+  List.fold_left merge empty lst
+
+let list_map ordered ?collapse_key fn input ~ctx =
+  let results =
+    map_reduce ordered ?collapse_key
+      ~map: (fun t -> fn t ~ctx)
+      ~merge: ctx.merge
+      ~empty: ctx.empty
+      input
+  in
+  let+ state = Current.state ~hidden:true results
+  and+ input = Current.state ~hidden:true input
+  in
+  match input, state with
+  | Error _, _ -> ctx.empty (* Ignore any error coming from the input. *)
+  | Ok _, Ok x -> x
+  | Ok _, Error (`Msg m) -> failwith m
+  | Ok _, Error (`Active _) ->
+    Logs.warn (fun f -> f "Node.list_map: input is ready but output is pending!");
+    ctx.empty
+
+
+let collapse ~key ~value ~input t ~ctx =
+  Current.collapse ~key ~value ~input (t ~ctx)
 
 let job_id job =
   let+ md = Current.Analysis.metadata job in
   match md with
   | Some { Current.Metadata.job_id; _ } -> job_id
   | None -> None
-
-let root children = Root children
-let branch ~label children = Branch { label; action = None; children }
-let actioned_branch ~label action children = Branch { label; action = Some action; children }
-let leaf ~label action = Branch { label; action = Some action; children = [] }
-
-let action kind job =
-  let+ job_id = job_id job
-  and+ result = job |> Current.map (fun _ -> kind) |> Current.state ~hidden:true
-  in
-  { job_id; result }
-
-let rec flatten ~prefix acc f = function
-  | Root children ->
-    flatten_children ~prefix acc f children
-  | Branch { label; action = None; children } ->
-    let prefix = prefix ^ label ^ status_sep in
-    flatten_children ~prefix acc f children
-  | Branch { label; action = Some { job_id; result }; children } ->
-    let prefix_children = prefix ^ label ^ status_sep in
-    let label = prefix ^ label in
-    Index.Job_map.add label (f ~job_id ~result) (flatten_children ~prefix:prefix_children acc f children)
-and flatten_children ~prefix acc f children =
-  List.fold_left (fun acc child -> flatten ~prefix acc f child) acc children
-
-let flatten f t = flatten Index.Job_map.empty f t ~prefix:""
-
-let pp_result f = function
-  | Ok `Built -> Fmt.string f "built"
-  | Ok `Analysed -> Fmt.string f "analysed"
-  | Ok `Linted -> Fmt.string f "linted"
-  | Error (`Active _) -> Fmt.string f "active"
-  | Error (`Msg m) -> Fmt.string f m
-
-let rec dump f = function
-  | Root children ->
-    Fmt.pf f "@[<v>%a@]"
-      (Fmt.(list ~sep:cut) dump) children
-  | Branch { label; action = None; children } ->
-    Fmt.pf f "@[<v2>%s%a@]"
-      label
-      Fmt.(list ~sep:nop (cut ++ dump)) children
-  | Branch { label; action = Some { job_id = _; result }; children } ->
-    Fmt.pf f "@[<v2>%s (%a)%a@]"
-      label
-      pp_result result
-      Fmt.(list ~sep:nop (cut ++ dump)) children

--- a/service/node.mli
+++ b/service/node.mli
@@ -1,34 +1,46 @@
-open Opam_repo_ci
+type kind = [`Built | `Analysed | `Linted]
 
-type action
-(** A result *)
+type 'a t
+(** A tree of ocurrent results. *)
 
-type t
-(** A node in the tree of results. *)
+type 'a f = { f: 'x . label: string Current.t -> kind -> 'x Current.t -> 'a Current.t }
+(** A mapping function for the leaves of the tree: It's quantified over its input ['x Current.t] as the actions can produce anything, so [f] will only be able to extract their metadata with [job_id] and/or [Current.state]. *)
 
-val actioned_branch : label:string -> action -> t list -> t
-(** [actioned_branch ~label action children] is a branch node with an
-    action directly attached to the node itself. *)
+val flatten : 'a t -> map: 'a f -> merge: ('a -> 'a -> 'a) -> empty: 'a -> 'a Current.t
+(** [flatten t ~map ~merge ~empty] applies [map] to every [action] leaves of the tree, then fold all the results with the [merge] function (which should be associative, commutative, with [empty] as its zero). *)
 
-val branch : label:string -> t list -> t
-(** [branch ~label children] is a branch node. *)
+val empty : 'a t
+(** An [empty] tree with no leaf. *)
 
-val root : t list -> t
+val root : 'a t list -> 'a t
 (** [root children] is a branch with no label, used for the root node. *)
 
-val leaf : label:string -> action -> t
+val leaf : label:string -> 'a t -> 'a t
 (** [leaf ~label action] is a leaf node. *)
 
-val action : [ `Built | `Analysed | `Linted ] -> _ Current.t -> action Current.t
-(** [action kind job] is a result whose status is the state of [job]
-    but with the value replaced with [kind]. The job ID is extracted from the
-    job (so [job] must be a primitive). Although the result is a [Current.t] it
-    is always successful and immediately available. *)
+val leaf_dyn : label:string Current.t -> 'a t -> 'a t
+(** Same as [leaf], but with a dynamic [label]. *)
 
-val flatten :
-  (job_id:string option ->
-   result:[ `Built | `Analysed | `Linted ] Current_term.Output.t -> 'a) ->
-  t -> 'a Index.Job_map.t
-(** [flatten f t] converts the tree to a list, applying [f] to each element. *)
+val action : [ `Built | `Analysed | `Linted ] -> 'a Current.t -> 'b t
+(** [action kind job] is a leaf that will be mapped by [flatten]. *)
 
-val dump : t Fmt.t
+val actioned_branch : label:string -> 'a t -> 'a t list -> 'a t
+(** [actioned_branch ~label action children] is a branch node with an action directly attached to the node itself. *)
+
+val actioned_branch_dyn : label:string Current.t -> 'a t -> 'a t list -> 'a t
+(** Same as [actionned_branch], but with a dynamic [label]. *)
+
+val branch : label:string -> 'a t list -> 'a t
+(** [branch ~label children] is a branch node. *)
+
+val branch_dyn : label:string Current.t -> 'a t list -> 'a t
+(** Same as [branch], but with a dynamic [label]. *)
+
+val list_map : (module Current_term.S.ORDERED with type t = 'a) -> ?collapse_key:string -> ('a Current.t -> 'b t) -> 'a list Current.t -> 'b t
+(** [list_map ord ?collapse_key f lst] is the dynamic list [Current.list_map ord ?collapse_key f lst], except that its output is fixed to [empty] until the input [lst] is successful. You must ensure that the status of the input [lst] is reported elsewhere. *)
+
+val collapse : key:string -> value:string -> input:_ Current.t -> 'a t -> 'a t
+(** [collapse ~key ~value ~input t] performs [Current.collapse]. *)
+
+val job_id : 'a Current.t -> Current.job_id option Current.t
+(** [job_id t] is the job id associated with the ocurrent term [t], or [None] if the job hasn't been created yet (or if [t] is not an ocurrent primitive). *)

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -56,22 +56,6 @@ let with_label l t =
   let> v = t in
   Current.Primitive.const v
 
-(* [dep_list_map] is like [Current.list_map], except that the output is fixed to the empty list until
-   the input is successful. You must ensure that the status of the input is reported elsewhere. *)
-let dep_list_map (type a) (module M : Current_term.S.ORDERED with type t = a) ?collapse_key f input =
-  let results = Current.list_map ?collapse_key (module M) f input in
-  let+ state = Current.state ~hidden:true results
-  and+ input = Current.state ~hidden:true input
-  in
-  match input, state with
-  | Error _, _ -> []
-  | Ok _, Ok x -> x
-  (* The results of a [dep_list_map] are nodes, so they should always be ready and successful. *)
-  | Ok _, Error (`Msg m) -> failwith m
-  | Ok _, Error (`Active _) ->
-    Logs.warn (fun f -> f "dep_list_map: input is ready but output is pending!");
-    []
-
 let build_spec ~platform ~opam_version pkg =
   let+ pkg = pkg in
   Build.Spec.opam ~platform ~lower_bounds:false ~with_tests:false ~opam_version pkg
@@ -99,21 +83,21 @@ let test_revdeps ~ocluster ~opam_version ~master ~base ~platform ~pkgopt ~after 
   in
   let pkg = Current.map (fun {PackageOpt.pkg = pkg; urgent = _} -> pkg) pkgopt in
   let urgent = Current.map (fun {PackageOpt.pkg = _; urgent} -> urgent) pkgopt in
-  let+ tests =
+  let tests =
     revdeps
-    |> dep_list_map (module OpamPackage) (fun revdep ->
+    |> Node.list_map (module OpamPackage) (fun revdep ->
         let image =
           let spec = revdep_spec ~platform ~opam_version ~revdep pkg in
           Build.v ocluster ~label:"build" ~base ~spec ~master ~urgent source
         in
-        let+ label = Current.map OpamPackage.to_string revdep
-        and+ build = Node.action `Built image
+        let label = Current.map OpamPackage.to_string revdep
+        and build = Node.action `Built image
         in
-        Node.leaf ~label build
+        Node.leaf_dyn ~label build
       )
-  and+ list_revdeps = Node.action `Analysed revdeps
+  and list_revdeps = Node.action `Analysed revdeps
   in
-  [Node.actioned_branch ~label:"revdeps" list_revdeps tests]
+  Node.actioned_branch ~label:"revdeps" list_revdeps [tests]
 
 let get_significant_available_pkg = function
   | pkg, Analyse.Analysis.New -> Some {PackageOpt.pkg; urgent = None}
@@ -136,7 +120,7 @@ let build_with_cluster ~ocluster ~analysis ~lint ~master source =
       and+ pkgs = pkgs in
       pkgs
     in
-    pkgs |> dep_list_map ~collapse_key:"pkg" (module PackageOpt) (fun pkgopt ->
+    pkgs |> Node.list_map ~collapse_key:"pkg" (module PackageOpt) (fun pkgopt ->
         let pkg = Current.map (fun {PackageOpt.pkg; urgent = _} -> pkg) pkgopt in
         let urgent = Current.return None in
         let base =
@@ -157,47 +141,44 @@ let build_with_cluster ~ocluster ~analysis ~lint ~master source =
           let spec = test_spec ~platform ~opam_version pkg in
           Build.v ocluster ~label:"test" ~base ~spec ~master ~urgent source
         in
-        let+ pkg = pkg
-        and+ build = Node.action `Built image
-        and+ tests = Node.action `Built tests
-        and+ lower_bounds_check =
+        let build = Node.action `Built image
+        and tests = Node.action `Built tests
+        and lower_bounds_check =
           match opam_version, lower_bounds with
           | `V2_1, true ->
             let action =
               let spec = lower_bounds_spec ~platform ~opam_version pkg in
               Build.v ocluster ~label:"lower-bounds" ~base ~spec ~master ~urgent source
             in
-            let+ action = Node.action `Built action in
-            [Node.leaf ~label:"lower-bounds" action]
+            let action = Node.action `Built action in
+            Node.leaf ~label:"lower-bounds" action
           | `V2_0, true
           | (`V2_1 | `V2_0), false ->
-            Current.return []
-        and+ revdeps =
+            Node.empty
+        and revdeps =
           if revdeps then test_revdeps ~ocluster ~opam_version ~master ~base ~platform ~pkgopt source ~after:image
-          else Current.return []
+          else Node.empty
         in
-        let label = OpamPackage.to_string pkg in
-        Node.actioned_branch ~label build (
-          Node.leaf ~label:"tests" tests ::
-          lower_bounds_check @
-          revdeps
-        )
+        let label = Current.map OpamPackage.to_string pkg in
+        Node.actioned_branch_dyn ~label build [
+          Node.leaf ~label:"tests" tests;
+          lower_bounds_check;
+          revdeps;
+        ]
       )
-    |> Current.map (Node.branch ~label)
-    |> Current.collapse ~key:"platform" ~value:label ~input:analysis
+    |> (fun x -> Node.branch ~label [x])
+    |> Node.collapse ~key:"platform" ~value:label ~input:analysis
   in
   let compilers ~opam_version =
-    Current.list_seq begin
-      let master_distro = Dockerfile_distro.tag_of_distro master_distro in
-      (Ocaml_version.Releases.recent @ Ocaml_version.Releases.unreleased_betas) |>
-      List.map (fun v ->
-        let v = Ocaml_version.with_just_major_and_minor v in
-        let revdeps = Ocaml_version.equal v default_compiler in (* TODO: Remove this when the cluster is ready *)
-        let v = Ocaml_version.to_string v in
-        let variant = Variant.v ~arch:`X86_64 ~distro:master_distro ~compiler:(v, None) in
-        build ~opam_version ~lower_bounds:true ~revdeps v variant
-      )
-    end
+    let master_distro = Dockerfile_distro.tag_of_distro master_distro in
+    (Ocaml_version.Releases.recent @ Ocaml_version.Releases.unreleased_betas) |>
+    List.map (fun v ->
+      let v = Ocaml_version.with_just_major_and_minor v in
+      let revdeps = Ocaml_version.equal v default_compiler in (* TODO: Remove this when the cluster is ready *)
+      let v = Ocaml_version.to_string v in
+      let variant = Variant.v ~arch:`X86_64 ~distro:master_distro ~compiler:(v, None) in
+      build ~opam_version ~lower_bounds:true ~revdeps v variant
+    )
   in
   let distributions ~opam_version =
     let default_compiler = Ocaml_version.to_string default_compiler in
@@ -220,37 +201,35 @@ let build_with_cluster ~ocluster ~analysis ~lint ~master source =
         build ~opam_version ~lower_bounds:false ~revdeps:false distro variant
       )
     in
-    Current.list_seq (macos_distributions @ linux_distributions)
+    macos_distributions @ linux_distributions
   in
-  let+ analysis = Node.action `Analysed analysis
-  and+ lint = Node.action `Linted lint
-  and+ compilers_2_0 = compilers ~opam_version:`V2_0
-  and+ compilers_2_1 = compilers ~opam_version:`V2_1
-  and+ distributions_2_0 = distributions ~opam_version:`V2_0
-  and+ distributions_2_1 = distributions ~opam_version:`V2_1
-  and+ extras =
+  let analysis = Node.action `Analysed analysis
+  and lint = Node.action `Linted lint
+  and compilers_2_0 = compilers ~opam_version:`V2_0
+  and compilers_2_1 = compilers ~opam_version:`V2_1
+  and distributions_2_0 = distributions ~opam_version:`V2_0
+  and distributions_2_1 = distributions ~opam_version:`V2_1
+  and extras =
     let master_distro = Dockerfile_distro.tag_of_distro master_distro in
     let default_comp = Ocaml_version.to_string default_compiler in
-    Current.list_seq (
-      List.filter_map (fun v ->
-        match Ocaml_version.extra v with
-        | None -> None
-        | Some label ->
-            (* TODO: This should be in ocaml-version or ocaml-dockerfile *)
-            (* TODO: The same code is used in docker-base-images *)
-            let label = String.map (function '+' -> '-' | c -> c) label in
-            let variant = Variant.v ~arch:`X86_64 ~distro:master_distro ~compiler:(default_comp, Some label) in
-            Some (build ~opam_version:`V2_1 ~lower_bounds:false ~revdeps:false label variant)
-      ) (Ocaml_version.Opam.V2.switches `X86_64 default_compiler_full) @
-      List.filter_map (function
-        | `X86_64 -> None
-        | `Riscv64 -> None (* TODO: unlock this one when more machines are available *)
-        | arch ->
-            let label = Ocaml_version.to_opam_arch arch in
-            let variant = Variant.v ~arch ~distro:master_distro ~compiler:(default_comp, None) in
-            Some (build ~opam_version:`V2_1 ~lower_bounds:false ~revdeps:false label variant)
-      ) Ocaml_version.arches
-    )
+    List.filter_map (fun v ->
+      match Ocaml_version.extra v with
+      | None -> None
+      | Some label ->
+          (* TODO: This should be in ocaml-version or ocaml-dockerfile *)
+          (* TODO: The same code is used in docker-base-images *)
+          let label = String.map (function '+' -> '-' | c -> c) label in
+          let variant = Variant.v ~arch:`X86_64 ~distro:master_distro ~compiler:(default_comp, Some label) in
+          Some (build ~opam_version:`V2_1 ~lower_bounds:false ~revdeps:false label variant)
+    ) (Ocaml_version.Opam.V2.switches `X86_64 default_compiler_full) @
+    List.filter_map (function
+      | `X86_64 -> None
+      | `Riscv64 -> None (* TODO: unlock this one when more machines are available *)
+      | arch ->
+          let label = Ocaml_version.to_opam_arch arch in
+          let variant = Variant.v ~arch ~distro:master_distro ~compiler:(default_comp, None) in
+          Some (build ~opam_version:`V2_1 ~lower_bounds:false ~revdeps:false label variant)
+    ) Ocaml_version.arches
   in
   let opam_2_0 =
     [
@@ -272,28 +251,66 @@ let build_with_cluster ~ocluster ~analysis ~lint ~master source =
     Node.branch ~label:"opam-2.1" opam_2_1;
   ]
 
-let summarise results =
-  let results = Node.flatten (fun ~job_id:_ ~result -> result) results in
-  let (ok, pending, err, skip, lint) =
-    Index.Job_map.fold (fun _ result (ok, pending, err, skip, lint) ->
-      match result with
-      | Ok `Analysed -> (ok, pending, err, skip, lint)
-      | Ok `Linted -> (ok, pending, err, skip, lint + 1)
-      | Ok `Built -> (ok + 1, pending, err, skip, lint)
-      | Error `Msg m when Astring.String.is_prefix ~affix:"[SKIP]" m -> (ok, pending, err, skip + 1, lint)
-      | Error `Msg _ -> (ok, pending, err + 1, skip, lint)
-      | Error `Active _ -> (ok, pending + 1, err, skip, lint)
-      (* TODO: Find a way to use the labels and error messages to display something more useful *)
-    ) results (0, 0, 0, 0, 0)
-  in
-  let lint = if lint > 0 then "ok" else "failed" in
-  if pending > 0 then Error (`Active `Running)
-  else match ok, err, skip with
-    | 0, 0, 0 -> Ok "No build was necessary"
-    | 0, 0, _skip -> Error (`Msg "Everything was skipped")
-    | ok, 0, 0 -> Ok (Fmt.str "%d jobs passed" ok)
-    | ok, 0, skip -> Ok (Fmt.str "%d jobs passed, %d jobs skipped" ok skip)
-    | ok, err, skip -> Error (`Msg (Fmt.str "%d jobs failed, lint: %s, %d jobs skipped, %d jobs passed" err lint skip ok))
+
+module Summary = struct
+  type t = { ok: int; pending: int; err: int; skip: int; lint: int }
+
+  let merge a b =
+    {
+      ok = a.ok + b.ok;
+      pending = a.pending + b.pending;
+      err = a.err + b.err;
+      skip = a.skip + b.skip;
+      lint = a.lint + b.lint;
+    }
+
+  let empty = { ok = 0; pending = 0; err = 0; skip = 0; lint = 0 }
+  let ok = { empty with ok = 1 }
+  let pending = { empty with pending = 1 }
+  let err = { empty with err = 1 }
+  let skip = { empty with skip = 1 }
+  let lint = { empty with lint = 1 }
+
+  let of_current t =
+    let+ result = Current.state ~hidden:true t in
+    match result with
+    | Ok `Analysed -> empty
+    | Ok `Linted -> lint
+    | Ok `Built -> ok
+    | Error `Msg m when Astring.String.is_prefix ~affix:"[SKIP]" m -> skip
+    | Error `Msg _ -> err
+    | Error `Active _ -> pending
+
+  let to_string { ok; pending; err; skip; lint } =
+    let lint = if lint > 0 then "ok" else "failed" in
+    if pending > 0 then Error (`Active `Running)
+    else match ok, err, skip with
+      | 0, 0, 0 -> Ok "No build was necessary"
+      | 0, 0, _skip -> Error (`Msg "Everything was skipped")
+      | ok, 0, 0 -> Ok (Fmt.str "%d jobs passed" ok)
+      | ok, 0, skip -> Ok (Fmt.str "%d jobs passed, %d jobs skipped" ok skip)
+      | ok, err, skip -> Error (`Msg (Fmt.str "%d jobs failed, lint: %s, %d jobs skipped, %d jobs passed" err lint skip ok))
+end
+
+module Results : sig
+  type t = Index.job_ids Current.t * Summary.t Current.t
+  val empty : t
+  val merge : t -> t -> t
+end = struct
+  type t = Index.job_ids Current.t * Summary.t Current.t
+
+  let empty = (Current.return Index.Job_map.empty, Current.return Summary.empty)
+
+  let map2 f x y =
+    let+ x = x
+    and+ y = y
+    in f x y
+
+  let merge (j1, s1) (j2, s2) =
+    let impossible name _ _ = Printf.kprintf failwith "Two jobs have the same name %S" name in
+    map2 (Index.Job_map.union impossible) j1 j2,
+    map2 Summary.merge s1 s2
+end
 
 (* An in-memory-only latch of the last successful value. *)
 let latch ~label x =
@@ -327,12 +344,10 @@ let get_prs repo =
   in
   master, prs
 
-let test_repo ~ocluster ~push_status repo =
-  let master, prs = get_prs repo in
-  let master = latch ~label:"master" master in  (* Don't cancel builds while fetching updates to this *)
-  let prs = set_active_refs ~repo prs in
-  prs |> Current.list_iter ~collapse_key:"pr" (module Github.Api.Commit) @@ fun head ->
+let test_pr ~ocluster ~master ~head =
+  let repo = Current.map Current_github.Api.Commit.repo_id head in
   let commit_id = Current.map Github.Api.Commit.id head in
+  let hash = Current.map Git.Commit_id.hash commit_id in
   let src = Git.fetch commit_id in
   let analysis = Analyse.examine ~master src in
   let lint =
@@ -340,28 +355,54 @@ let test_repo ~ocluster ~push_status repo =
     Lint.check ~master ~packages src
   in
   let builds = build_with_cluster ~ocluster ~analysis ~lint ~master commit_id in
-  let summary = Current.map summarise builds in
-  let status =
-    let+ summary = summary in
-    match summary with
-    | Ok _ -> `Passed
-    | Error (`Active `Running) -> `Pending
-    | Error (`Msg _) -> `Failed
+  let* (jobs, summary) =
+    Node.flatten builds
+      ~map:{ Node.f = fun ~label kind job ->
+              let db_record =
+                let+ variant = label
+                and+ job_id = Node.job_id job
+                in
+                Index.Job_map.singleton variant job_id
+              in
+              let result =
+                let+ _ = job in
+                kind
+              in
+              Current.return (db_record, Summary.of_current result)
+      }
+      ~merge:Results.merge
+      ~empty:Results.empty
   in
-  let index =
-    let+ commit = head
-    and+ jobs = Current.map (Node.flatten (fun ~job_id ~result:_ -> job_id)) builds
-    and+ status = status in
-    let repo = Current_github.Api.Commit.repo_id commit in
-    let hash = Current_github.Api.Commit.hash commit in
-    Index.record ~repo ~hash ~status jobs
-  and set_github_status =
+  let+ () =
+    let+ jobs = jobs
+    and+ repo = repo
+    and+ hash = hash in
+    Index.record ~repo ~hash jobs
+  and+ summary =
+    let+ summary = summary
+    and+ { Current_github.Repo_id.owner; name } = repo
+    and+ hash = hash in
+    let summary = Summary.to_string summary in
+    let status =
+      match summary with
+      | Ok _ -> `Passed
+      | Error (`Active `Running) -> `Pending
+      | Error (`Msg _) -> `Failed
+    in
+    Index.set_status ~owner ~name ~hash status;
     summary
+  in
+  summary
+
+let test_repo ~ocluster ~push_status repo =
+  let master, prs = get_prs repo in
+  let master = latch ~label:"master" master in  (* Don't cancel builds while fetching updates to this *)
+  let prs = set_active_refs ~repo prs in
+  prs |> Current.list_iter ~collapse_key:"pr" (module Github.Api.Commit) @@ fun head ->
+    test_pr ~ocluster ~master ~head
     |> github_status_of_state ~head
     |> (if push_status then Github.Api.Commit.set_status head "opam-ci"
         else Current.ignore_value)
-  in
-  Current.all [index; set_github_status]
 
 let local_test ~ocluster repo () =
   let { Github.Repo_id.owner; name = _ } = Github.Api.Repo.id repo in

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -14,17 +14,18 @@ let test_simple () =
   Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
                                      VALUES ('test', x'00', 'job1', x'01', 1, x'02', '2019-11-01 9:00', '2019-11-01 9:01', '2019-11-01 9:02', 0)";
   Index.set_active_refs ~repo ["master", hash];
-  Index.record ~repo ~hash ~status:`Pending @@ Index.Job_map.of_list [ "analysis", Some "job1";
-                             "alpine", None ];
+  Index.set_status ~owner ~name ~hash `Pending;
+  Index.record ~repo ~hash @@ Index.Job_map.of_list [ "analysis", Some "job1"; "alpine", None ];
   Alcotest.(check (list string)) "Repos" ["name"] @@ Index.list_repos owner;
   Alcotest.(check (list (pair string string))) "Refs" ["master", hash] @@ Index.get_active_refs repo;
   Alcotest.(check jobs) "Jobs" ["alpine", `Not_started; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
   Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
                                      VALUES ('test', x'01', 'job2', x'01', 0, x'21', '2019-11-01 9:03', '2019-11-01 9:04', '2019-11-01 9:05', 0)";
-  Index.record ~repo ~hash ~status:`Failed @@ Index.Job_map.of_list [ "analysis", Some "job1";
-                             "alpine", Some "job2" ];
+  Index.set_status ~owner ~name ~hash `Failed;
+  Index.record ~repo ~hash @@ Index.Job_map.of_list [ "analysis", Some "job1"; "alpine", Some "job2" ];
   Alcotest.(check jobs) "Jobs" ["alpine", `Failed "!"; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
-  Index.record ~repo ~hash ~status:`Passed @@ Index.Job_map.of_list [ "analysis", Some "job1" ];
+  Index.set_status ~owner ~name ~hash `Passed;
+  Index.record ~repo ~hash @@ Index.Job_map.of_list [ "analysis", Some "job1" ];
   Alcotest.(check jobs) "Jobs" ["analysis", `Passed] @@ Index.get_jobs ~owner ~name hash
 
 let tests = [


### PR DESCRIPTION
It turns out that this operation is very expensive when there are lots of jobs:

https://github.com/ocurrent/opam-repo-ci/blob/8e5c148d1789f30f74b6b39feb7e1e22c5b83057/lib/index.ml#L109

... as it fetches all the known jobs for that `hash` from sqlite to check if it's necessary to update them. On the you-know-which PR and without https://github.com/ocurrent/ocurrent/pull/318, the pipeline just keeps on reading >150k entries only to discover that no change actually happened to their `job_id`.

It's almost (!) fine with the ocurrent fix... But the opam-repo-ci pipeline also builds the `Node` tree as a way of counting the number of successes, errors, pending jobs, etc and this makes it hard to differentiate between a `summary` change and a `job_id` update, so I had to shuffle things around a bit. I tried to keep the pipeline logic as close to the original, but some complexity ended up in the `Node` abstraction:
- Before, it was a standard value used to accumulate all the metadatas in a `Node.t Current.t`, but with this proposal the `Node` is now driving the ocurrent computation: it will perform the `let+`/`and+` and pass around a `ctx` that contains the "tree path" `label` so that each job knows "what name they have" (ie it wraps a reader monad on top of ocurrent)
- To run (`flatten`) the final root `Node`, a `map` continuation is applied to each `action` leaf of the tree (= each primitive job) such that we get the opportunity to store their `job_id` in the sqlite db, and observe their `Current.state`.
- `Node` then folds and `merge`s all the jobs summaries incrementally so that we can update the github status / `Index.Status_cache` in the final step

A small question: previously `Index.record` had the ability to remove entries from the db but I wasn't able to understand when that would happen? (except that `Job_map.merge` required to handle this case -- but then it was also a test case so I'm not sure)

On my computer I also needed https://github.com/ocurrent/current_incr/pull/4 to reduce the major heap size to an acceptable level and avoid swapping (but you can try without this patch if you think you have enough ram)

Finally please note that I had to clean up a few things blind before submitting this PR... and I can only hope that I didn't mess things up at the last minute! It typechecks ^^' but it should be tested somewhere that resemble production!