### PR TITLE
Speedup and trim the jobs

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -24,7 +24,7 @@ module Spec = struct
     revdep : package option;
     with_tests : bool;
     lower_bounds : bool;
-    opam_version : [`V2_0 | `V2_1];
+    opam_version : [`V2_0 | `V2_1 | `Dev];
   } [@@deriving to_yojson]
 
   type ty = [
@@ -55,6 +55,7 @@ module Spec = struct
         (match opam_version with
          | `V2_0 -> "2.0"
          | `V2_1 -> "2.1"
+         | `Dev -> "dev"
         )
 end
 

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -6,7 +6,7 @@ module Spec : sig
     platform:Platform.t ->
     lower_bounds:bool ->
     with_tests:bool ->
-    opam_version:[`V2_0 | `V2_1] ->
+    opam_version:[`V2_0 | `V2_1 | `Dev] ->
     OpamPackage.t ->
     t
 end

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -1,6 +1,6 @@
 val spec :
   for_docker:bool ->
-  opam_version:[`V2_0 | `V2_1] ->
+  opam_version:[`V2_0 | `V2_1 | `Dev] ->
   base:string ->
   variant:Variant.t ->
   revdep:OpamPackage.t option ->

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -205,9 +205,7 @@ let build_with_cluster ~ocluster ~analysis ~lint ~master source =
   in
   let analysis = Node.action `Analysed analysis
   and lint = Node.action `Linted lint
-  and compilers_2_0 = compilers ~opam_version:`V2_0
   and compilers_2_1 = compilers ~opam_version:`V2_1
-  and distributions_2_0 = distributions ~opam_version:`V2_0
   and distributions_2_1 = distributions ~opam_version:`V2_1
   and extras =
     let master_distro = Dockerfile_distro.tag_of_distro master_distro in
@@ -231,12 +229,6 @@ let build_with_cluster ~ocluster ~analysis ~lint ~master source =
           Some (build ~opam_version:`V2_1 ~lower_bounds:false ~revdeps:false label variant)
     ) Ocaml_version.arches
   in
-  let opam_2_0 =
-    [
-      Node.branch ~label:"compilers" compilers_2_0;
-      Node.branch ~label:"distributions" distributions_2_0;
-    ]
-  in
   let opam_2_1 =
     [
       Node.branch ~label:"compilers" compilers_2_1;
@@ -247,7 +239,6 @@ let build_with_cluster ~ocluster ~analysis ~lint ~master source =
   Node.root [
     Node.leaf ~label:"(analysis)" analysis;
     Node.leaf ~label:"(lint)" lint;
-    Node.branch ~label:"opam-2.0" opam_2_0;
     Node.branch ~label:"opam-2.1" opam_2_1;
   ]
 

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -207,11 +207,12 @@ let build_with_cluster ~ocluster ~analysis ~lint ~master source =
   in
   let analysis = Node.action `Analysed analysis
   and lint = Node.action `Linted lint
-  and compilers_2_1 = compilers ~opam_version:`V2_1
-  and distributions_2_1 = distributions ~opam_version:`V2_1
   and extras =
     let master_distro = Dockerfile_distro.tag_of_distro master_distro in
     let default_comp = Ocaml_version.to_string default_compiler in
+    let default_variant = Variant.v ~arch:`X86_64 ~distro:master_distro ~compiler:(default_comp, None) in
+    build ~opam_version:`V2_0 ~lower_bounds:false ~revdeps:false "opam-2.0" default_variant ::
+    build ~opam_version:`V2_1 ~lower_bounds:false ~revdeps:false "opam-2.1" default_variant ::
     List.filter_map (fun v ->
       match Ocaml_version.extra v with
       | None -> None

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -186,7 +186,9 @@ let build_with_cluster ~ocluster ~analysis ~lint ~master source =
       Dockerfile_distro.active_distros `X86_64 |>
       List.fold_left (fun acc distro ->
         if Dockerfile_distro.compare distro master_distro = 0 (* TODO: Add Dockerfile_distro.equal *)
-        || Dockerfile_distro.os_family_of_distro distro <> `Linux then (* TODO: Unlock this when Windows is ready *)
+        || Dockerfile_distro.os_family_of_distro distro <> `Linux (* TODO: Unlock this when Windows is ready *)
+        || Dockerfile_distro.compare distro (`CentOS `V7 : Dockerfile_distro.t) = 0 (* TODO: Remove when it has been removed in ocaml-dockerfile *)
+        || Dockerfile_distro.compare distro (`OracleLinux `V7 : Dockerfile_distro.t) = 0 then
           acc
         else
           let distro = Dockerfile_distro.tag_of_distro distro in


### PR DESCRIPTION
Apart from the last two commits this only ports things that have been in `live` for 6+ months.
* Testing both opam 2.0 and 2.1 for everything was wasteful and redundant so we only test it once for each
* Using `opam-dev` when possible greatly improves performence in the cluster (see https://github.com/ocurrent/ocluster/issues/114 and https://github.com/ocaml/opam/issues/4586)