### PR TITLE
List the revdeps using the correct opam version

### DIFF
--- a/lib/build.mli
+++ b/lib/build.mli
@@ -32,6 +32,7 @@ val v :
 val list_revdeps :
   t ->
   platform:Platform.t ->
+  opam_version:[`V2_0 | `V2_1 | `Dev] ->
   pkgopt:PackageOpt.t Current.t ->
   base:base Current.t ->
   master:Current_git.Commit.t Current.t ->

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -128,12 +128,11 @@ let spec ~for_docker ~opam_version ~base ~variant ~revdep ~lower_bounds ~with_te
     @ tests
   )
 
-let revdeps ~for_docker ~base ~variant ~pkg =
+let revdeps ~for_docker ~opam_version ~base ~variant ~pkg =
   let open Obuilder_spec in
   let pkg = Filename.quote (OpamPackage.to_string pkg) in
   Obuilder_spec.stage ~from:base (
-    (* TODO: Switch to opam 2.1 when https://github.com/ocaml/opam/issues/4311 is fixed *)
-    setup_repository ~variant ~for_docker ~opam_version:`V2_0
+    setup_repository ~variant ~for_docker ~opam_version
     @ [
       run "echo '@@@OUTPUT' && \
            opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --recursive --depopts && \

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -11,6 +11,7 @@ val spec :
 
 val revdeps :
   for_docker:bool ->
+  opam_version:[`V2_0 | `V2_1 | `Dev] ->
   base:string ->
   variant:Variant.t ->
   pkg:OpamPackage.t ->

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -79,7 +79,7 @@ let revdep_spec ~platform ~opam_version ~revdep pkg =
    (using [spec] and [base], merging [source] into [master]). *)
 let test_revdeps ~ocluster ~opam_version ~master ~base ~platform ~pkgopt ~after source =
   let revdeps =
-    Build.list_revdeps ~base ocluster ~platform ~pkgopt ~master ~after source |>
+    Build.list_revdeps ~opam_version ~base ocluster ~platform ~pkgopt ~master ~after source |>
     Current.map OpamPackage.Set.elements
   in
   let pkg = Current.map (fun {PackageOpt.pkg = pkg; urgent = _} -> pkg) pkgopt in


### PR DESCRIPTION
Now that we are using the an up-to-date version of opam (see #175) we can fix the TODO comment in `lib/opam_build.ml`