### PR TITLE
Treat OCaml 4.14 (LTS) and 5.0 as both being the latest version of OCaml

### DIFF
--- a/lib/variant.ml
+++ b/lib/variant.ml
@@ -9,13 +9,16 @@ type t = {
   arch : arch;
 } [@@deriving to_yojson]
 
-let arch t = t.arch
-let docker_tag t =
+let pp_ocaml_version t =
   let variant = match t.ocaml_variant with
     | None -> ""
     | Some variant -> "-"^variant
   in
-  t.distribution^"-ocaml-"^t.ocaml_version^variant
+  t.ocaml_version^variant
+
+let arch t = t.arch
+let docker_tag t =
+  t.distribution^"-ocaml-"^pp_ocaml_version t
 let distribution t = t.distribution
 
 let pp f t = Fmt.pf f "%s/%s" (docker_tag t) (Ocaml_version.string_of_arch t.arch)

--- a/lib/variant.mli
+++ b/lib/variant.mli
@@ -4,6 +4,8 @@ type t [@@deriving to_yojson]
 
 val v : arch:arch -> distro:string -> compiler:(string * string option) -> t
 
+val pp_ocaml_version : t -> string
+
 val arch : t -> arch
 val docker_tag : t -> string
 val distribution : t -> string

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -224,7 +224,8 @@ let build_with_cluster ~ocluster ~analysis ~lint ~master source =
   and extras =
     let build ~opam_version ~distro ~arch ~compiler label =
       let variant = Variant.v ~arch ~distro ~compiler in
-      let label = Fmt.str "%s-ocaml-%s" label (Variant.pp_ocaml_version variant) in
+      let label = if String.equal label "" then "" else label^"-" in
+      let label = Fmt.str "%socaml-%s" label (Variant.pp_ocaml_version variant) in
       build ~opam_version ~lower_bounds:false ~revdeps:false label variant
     in
     let master_distro = Distro.tag_of_distro master_distro in
@@ -239,7 +240,7 @@ let build_with_cluster ~ocluster ~analysis ~lint ~master source =
             (* TODO: This should be in ocaml-version or ocaml-dockerfile *)
             (* TODO: The same code is used in docker-base-images *)
             let label = String.map (function '+' -> '-' | c -> c) label in
-            Some (build ~opam_version ~arch:`X86_64 ~distro:master_distro ~compiler:(comp, Some label) label)
+            Some (build ~opam_version ~arch:`X86_64 ~distro:master_distro ~compiler:(comp, Some label) "")
       ) (Ocaml_version.Opam.V2.switches `X86_64 comp_full) @
       List.filter_map (function
         | `X86_64 -> None


### PR DESCRIPTION
This duplicates all revdeps, distributions, macos and extra checks on both 4.14 and 5.0.

This will put more stress on the cluster but we probably need to keep it for medium term anyway given 4.14 is a LTS release and most releases will not adopt the 5.x right away.