### PR TITLE
Hotfix ocurrent/ocaml-dockerfile#132

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -90,7 +90,7 @@ let setup_repository ~variant ~for_docker ~opam_version =
   (* TODO: macOS seems to have a bug in (copy ...) so I am forced to remove the (workdir ...) here.
      Otherwise the "opam pin" after the "opam repository set-url" will fail (cannot find the new package for some reason) *)
   run "%s -f %s/bin/opam-%s %s/bin/opam" ln prefix opam_version_str prefix ::
-  run "opam init --reinit%s -ni" opamrc ::
+  run ~network "opam init --reinit%s -ni" opamrc :: (* TODO: Remove ~network when https://github.com/ocurrent/ocaml-dockerfile/pull/132 is merged *)
   env "OPAMDOWNLOADJOBS" "1" :: (* Try to avoid github spam detection *)
   env "OPAMERRLOGLEN" "0" :: (* Show the whole log if it fails *)
   env "OPAMSOLVERTIMEOUT" "500" :: (* Increase timeout. Poor mccs is doing its best *)


### PR DESCRIPTION
causes the log reader to detect the failure to update ocaml-beta-repository as the main cause of failure