### PR TITLE
Propagate master only when analysis changes

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -31,17 +31,17 @@ module Analysis = struct
     | Deleted
     | SignificantlyChanged
     | UnsignificantlyChanged
-  [@@deriving yojson]
+  [@@deriving eq, yojson]
 
   type data = {
     kind : kind;
     has_tests : bool;
-  } [@@deriving yojson]
+  } [@@deriving eq, yojson]
 
   type t = {
     packages : (OpamPackage.t * data) list;
   }
-  [@@deriving yojson]
+  [@@deriving eq, yojson]
 
   let marshal t = to_yojson t |> Yojson.Safe.to_string
 

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -16,6 +16,7 @@ module Analysis : sig
   val get_opam : cwd:Fpath.t -> string -> (string, unit) result Lwt.t
   val packages : t -> (OpamPackage.t * data) list
   val is_duniverse : t -> bool
+  val equal : t -> t -> bool
 end
 
 val examine :


### PR DESCRIPTION
Alternative to #204 cc @art-w 
We just have to wait for https://github.com/ocurrent/ocurrent/pull/330 to be merged and this is good to go.

Already being tested in production.