### PR TITLE
Skip building unavailable packages

### DIFF
--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -2,6 +2,7 @@ module Analysis : sig
   type kind =
     | New
     | Deleted
+    | Unavailable
     | SignificantlyChanged
     | UnsignificantlyChanged
   [@@deriving yojson]

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -189,7 +189,7 @@ module Check = struct
       match kind with
       | Analyse.Analysis.Deleted ->
           Lwt.return errors (* TODO *)
-      | Analyse.Analysis.(New | SignificantlyChanged | UnsignificantlyChanged) ->
+      | Analyse.Analysis.(New | Unavailable | SignificantlyChanged | UnsignificantlyChanged) ->
           get_opam ~cwd pkg >>= fun opam ->
           (* Check name field *)
           let errors = match OpamFile.OPAM.name_opt opam with

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -110,7 +110,7 @@ let test_revdeps ~ocluster ~opam_version ~master ~base ~platform ~pkgopt ~after 
 let get_significant_available_pkg = function
   | pkg, {Analyse.Analysis.kind = New; has_tests} -> Some {PackageOpt.pkg; urgent = None; has_tests}
   | pkg, {Analyse.Analysis.kind = SignificantlyChanged; has_tests} -> Some {PackageOpt.pkg; urgent = Some (fun (`High | `Low) -> false); has_tests}
-  | _, {Analyse.Analysis.kind = Deleted | UnsignificantlyChanged; _} -> None
+  | _, {Analyse.Analysis.kind = Deleted | Unavailable | UnsignificantlyChanged; _} -> None
 
 let build_with_cluster ~ocluster ~analysis ~lint ~master source =
   let pkgs = Current.map Analyse.Analysis.packages analysis in


### PR DESCRIPTION
opam-repo-ci crash-loops because https://github.com/ocaml/opam-repository/pull/23649 spawn too many jobs at once and the server it is currently in runs out of disk space. This PR (already in live to unlock this issue) fixes this by skipping building those unavailable packages