### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN opam config exec -- dune build ./_build/install/default/bin/opam-repo-ci-ser
 FROM debian:11
 RUN apt-get update && apt-get install libev4 openssh-client curl gnupg2 dumb-init git graphviz libsqlite3-dev ca-certificates netbase gzip bzip2 xz-utils unzip tar -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-RUN echo 'deb [arch=amd64] https://download.docker.com/linux/debian bullseye stable' >> /etc/apt/sources.list
+RUN echo 'deb [arch=arm64] https://download.docker.com/linux/debian bullseye stable' >> /etc/apt/sources.list
 RUN apt-get update && apt-get install docker-ce -y --no-install-recommends
 RUN git config --global user.name "ocaml" && git config --global user.email "ci"
 WORKDIR /var/lib/ocurrent

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ocaml/opam:debian-11-ocaml-4.14@sha256:d0ed341a7c8c0fcc1d976d670c587e58980671f88fe5cd5c9b86087e6fc5a0e4 AS build
+FROM ocaml/opam:debian-11-ocaml-4.14@sha256:18fcbeb356957c58cf8f37bc43adcca5683d50163a120d9b322b173428281e61 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto graphviz m4 pkg-config libsqlite3-dev libgmp-dev libffi-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard d16e9990e8b1cc2566a6d36c42b895c65bf0516a && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 15b381eeae1aa1c8b67b214ce1739344717aae89 && opam update
 COPY --chown=opam \
 	ocurrent/current_docker.opam \
 	ocurrent/current_github.opam \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,6 @@
-FROM ocaml/opam:debian-11-ocaml-4.14@sha256:d0ed341a7c8c0fcc1d976d670c587e58980671f88fe5cd5c9b86087e6fc5a0e4 AS build
+FROM ocaml/opam:debian-11-ocaml-4.14@sha256:18fcbeb356957c58cf8f37bc43adcca5683d50163a120d9b322b173428281e61 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev libffi-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard d16e9990e8b1cc2566a6d36c42b895c65bf0516a && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 15b381eeae1aa1c8b67b214ce1739344717aae89 && opam update
 COPY --chown=opam \
 	ocurrent/current_rpc.opam \
 	/src/ocurrent/


### PR DESCRIPTION
We need an ARM64 build for https://github.com/ocaml/infrastructure/issues/51.  However, `ocaml/opam:debian-11-ocaml-5.0@sha256:9eff20b27cbbe517f47d1d41a128291fe24f716d39ba539e62e37aeb18e7c34d` only contains an AMD64 build.