### PR TITLE
UI: Reorganize the summary of errors by type of errors to make things easier to read

### DIFF
--- a/web-ui/github.ml
+++ b/web-ui/github.ml
@@ -202,12 +202,22 @@ let link_jobs ~owner ~name ~hash ?selected jobs =
     in
     StatusTree.add k x trees
   in
+  let render_error trees { Client.variant; outcome } =
+    let k = [Fmt.str "%a" Client.State.pp outcome; variant] in
+    let x =
+      let uri = job_url ~owner ~name ~hash variant in
+      let label = String.split_on_char Common.status_sep variant in
+      let label = String.concat " / " label in
+      outcome, [a ~a:[a_href uri] [txt label]]
+    in
+    StatusTree.add k x trees
+  in
   let full_tree = statuses (List.fold_left render_job [] jobs) in
   let error_tree =
     if errors = [] then []
     else [
       h2 [txt "Summary of errors"];
-      statuses (List.fold_left render_job [] errors);
+      statuses (List.fold_left render_error [] errors);
     ]
   in
   error_tree @ [


### PR DESCRIPTION
Request by @UnixJunkie in https://github.com/ocaml/opam-repository/pull/24327#issuecomment-1705803328

Sadly this one makes things harder to read as the current error detection system isn't clever enough to regroup similar issues:
![scrn-2023-09-05-16-03-43](https://github.com/ocurrent/opam-repo-ci/assets/2611789/203b487e-b9cd-4425-8bfe-8c0ecd0e30f5)
