### PR TITLE
Make the revdeps calculation reflect more closely what is actually tested

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -154,9 +154,11 @@ let revdeps ~for_docker ~opam_version ~base ~variant ~pkg =
     setup_repository ~variant ~for_docker ~opam_version
     @ [
       run "echo '@@@OUTPUT' && \
-           opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --recursive --depopts && \
+           opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --depopts && \
+           opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --recursive && \
            opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --with-test --depopts && \
            echo '@@@OUTPUT'"
+        pkg pkg
         pkg pkg
         pkg pkg
     ]


### PR DESCRIPTION
Fixes https://github.com/ocurrent/opam-repo-ci/issues/227
Already deployed and tested successfully.

cc @chetmurthy