### PR TITLE
lint: Handle equality when parsing the dune version constraint

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -136,7 +136,7 @@ module Check = struct
     in
     let is_build = ref false in
     let rec get_lower_bound = function
-      | OpamFormula.Atom (OpamTypes.Constraint ((`Gt | `Geq), OpamTypes.FString version)) -> Some version
+      | OpamFormula.Atom (OpamTypes.Constraint ((`Gt | `Geq | `Eq), OpamTypes.FString version)) -> Some version
       | Atom (Filter (FIdent (_, var, _))) when String.equal (OpamVariable.to_string var) "build" -> is_build := true; None (* TODO: remove this hack *)
       | Empty | Atom (Filter _) | Atom (Constraint _) -> None
       | Block x -> get_lower_bound x


### PR DESCRIPTION
Detected by @jonahbeckford with the following dune constraint:
```
  "dune" {>= "3.6" & = "3.8.3" | = "3.8.3+shim"}
```