### PR TITLE
Enable -warn-error +partial-match by default to ensure changes in a dependency do not lead into unforseen runtime failures

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -112,6 +112,7 @@ let setup_repository ~variant ~for_docker ~opam_version =
   env "OPAMSOLVERTIMEOUT" "500" :: (* Increase timeout. Poor mccs is doing its best *)
   env "OPAMPRECISETRACKING" "1" :: (* Mitigate https://github.com/ocaml/opam/issues/3997 *)
   env "CI" "true" :: env "OPAM_REPO_CI" "true" :: (* Advertise CI for test frameworks *)
+  env "OCAMLPARAM" "warn-error=+8,_" :: (* https://github.com/ocaml/ocaml/issues/12475 *)
   [
     run "rm -rf opam-repository/";
     copy ["."] ~dst:"opam-repository/";


### PR DESCRIPTION
See https://github.com/ocaml/ocaml/issues/12475
Having this would've prevented https://github.com/ocaml/opam-repository/pull/24467 from occurring and warned the mdx maintainers that their package is not compatible yet.