### PR TITLE
Set the opam variable "ci" to true to be able to remove packages from the CI perspective

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -107,6 +107,7 @@ let setup_repository ~variant ~for_docker ~opam_version =
      Otherwise the "opam pin" after the "opam repository set-url" will fail (cannot find the new package for some reason) *)
   run "%s -f %s/bin/opam-%s %s/bin/opam" ln prefix opam_version_str prefix ::
   run ~network "opam init --reinit%s -ni" opamrc :: (* TODO: Remove ~network when https://github.com/ocurrent/ocaml-dockerfile/pull/132 is merged *)
+  run "opam var --global ci=true" :: (* To remove packages from the CI but not for users. See https://github.com/ocaml/opam-repository/issues/23697 *)
   env "OPAMDOWNLOADJOBS" "1" :: (* Try to avoid github spam detection *)
   env "OPAMERRLOGLEN" "0" :: (* Show the whole log if it fails *)
   env "OPAMSOLVERTIMEOUT" "500" :: (* Increase timeout. Poor mccs is doing its best *)


### PR DESCRIPTION
Implements the solution devised by myself and @emillon in https://github.com/ocaml/opam-repository/issues/23697 to remove packages from opam-repository from the CI perspective