### PR TITLE
Add aggregate Prometheus metric for PR statuses

### DIFF
--- a/lib/index.ml
+++ b/lib/index.ml
@@ -88,27 +88,63 @@ let get_job_ids ~owner ~name ~hash =
   get_job_ids_with_variant t ~owner ~name ~hash
   |> Job_map.bindings |> List.filter_map snd
 
+type n_per_status_t = { not_started : int; pending : int; failed : int; passed : int }
+
 module Status_cache = struct
-  let cache = Hashtbl.create 1_000
+  let cache : (string * string * string, build_status) Hashtbl.t = Hashtbl.create 1_000
   let cache_max_size = 1_000_000
 
-  type elt = [ `Not_started | `Pending | `Failed | `Passed ]
-
-  let add ~owner ~name ~hash (status : elt) =
+  let add ~owner ~name ~hash status =
     if Hashtbl.length cache > cache_max_size then Hashtbl.clear cache;
     Hashtbl.add cache (owner, name, hash) status
 
-  let find ~owner ~name ~hash : elt =
+  let find ~owner ~name ~hash =
     Hashtbl.find_opt cache (owner, name, hash)
     |> function
       | Some s -> s
       | None -> `Not_started
+
+  let empty_n_per_status = { not_started = 0; pending = 0; failed = 0; passed = 0 }
+
+  module Commit_map = Map.Make (struct
+    type t = string * string * string
+
+    (* Compare in reverse order as hashes are most likely to be distinct *)
+    let compare (a0, b0, c0) (a1, b1, c1) =
+      let x = String.compare c0 c1 in
+      if x = 0 then
+        let y = String.compare b0 b1 in
+        if y = 0 then String.compare a0 a1
+        else y
+      else x
+  end)
+
+  let sum_per_status () =
+    (* Deduplicates hashtbl, taking the most recent value for a given key *)
+    let hashtbl_to_map h =
+      Hashtbl.fold
+        (fun key status acc ->
+          if Commit_map.exists (fun k _ -> k = key) acc then acc
+          else Commit_map.add key status acc)
+        h
+        Commit_map.empty
+    in
+    let f _ status acc =
+      match status with
+      | `Not_started -> { acc with not_started = acc.not_started + 1 }
+      | `Pending -> { acc with pending = acc.pending + 1 }
+      | `Failed -> { acc with failed = acc.failed + 1 }
+      | `Passed -> { acc with passed = acc.passed + 1 }
+    in
+    let m = hashtbl_to_map cache in
+    Commit_map.fold f m empty_n_per_status
 end
 
 let get_status = Status_cache.find
 
-let set_status ~owner ~name ~hash status =
-  Status_cache.add ~owner ~name ~hash status
+let set_status = Status_cache.add
+
+let n_per_status = Status_cache.sum_per_status
 
 let record ~repo ~hash jobs =
   let { Current_github.Repo_id.owner; name } = repo in

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -50,6 +50,10 @@ val set_status:
   unit
 (** [set_status ~owner ~name ~hash build_status] sets the latest status for this combination. *)
 
+type n_per_status_t = { not_started : int; pending : int; failed : int; passed : int }
+
+val n_per_status : unit -> n_per_status_t
+
 val get_full_hash : owner:string -> name:string -> string -> (string, [> `Ambiguous | `Unknown | `Invalid]) result
 (** [get_full_hash ~owner ~name short_hash] returns the full hash for [short_hash]. *)
 

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -52,7 +52,7 @@ val set_status:
 
 type n_per_status_t = { not_started : int; pending : int; failed : int; passed : int }
 
-val n_per_status : unit -> n_per_status_t
+val get_n_per_status : unit -> n_per_status_t
 
 val get_full_hash : owner:string -> name:string -> string -> (string, [> `Ambiguous | `Unknown | `Invalid]) result
 (** [get_full_hash ~owner ~name short_hash] returns the full hash for [short_hash]. *)

--- a/service/local.ml
+++ b/service/local.ml
@@ -56,8 +56,7 @@ let submission_service =
 let cmd =
   let doc = "Test opam-repo-ci on a local Git clone" in
   let info = Cmd.info "opam-repo-ci-local" ~doc in
-  Cmd.v
-    info
+  Cmd.v info
     Term.(term_result (
       const main
       $ Current.Config.cmdliner

--- a/service/local.ml
+++ b/service/local.ml
@@ -8,9 +8,10 @@ module Github = Current_github
 let () =
   Memtrace.trace_if_requested ~context:"opam-repo-ci-local" ();
   Unix.putenv "DOCKER_BUILDKIT" "1";
-  Prometheus_unix.Logging.init ()
+  Prometheus_unix.Logging.init ();
+  Prometheus.CollectorRegistry.(register_pre_collect default) Metrics.update
 
-let main config mode capnp_address submission_uri api repo_id =
+let main config mode capnp_address submission_uri api repo_id prometheus_config =
   Lwt_main.run begin
     Capnp_setup.run capnp_address >>= fun (vat, rpc_engine_resolver) ->
     let repo = (api, repo_id) in
@@ -19,10 +20,15 @@ let main config mode capnp_address submission_uri api repo_id =
     rpc_engine_resolver |> Option.iter (fun r -> Capability.resolve_ok r (Api_impl.make_ci ~engine));
     let routes = Current_web.routes engine in
     let site = Current_web.Site.(v ~has_role:allow_all) ~name:"opam-repo-ci-local" routes in
-    Lwt.choose [
+    let prometheus =
+      List.map
+        (Lwt.map @@ Result.ok)
+        (Prometheus_unix.serve prometheus_config)
+    in
+    Lwt.choose ([
       Current.Engine.thread engine;
       Current_web.run ~mode site;
-    ]
+    ] @ prometheus)
   end
 
 (* Command-line parsing *)
@@ -50,6 +56,16 @@ let submission_service =
 let cmd =
   let doc = "Test opam-repo-ci on a local Git clone" in
   let info = Cmd.info "opam-repo-ci-local" ~doc in
-  Cmd.v info Term.(term_result (const main $ Current.Config.cmdliner $ Current_web.cmdliner $ Capnp_setup.cmdliner $ submission_service $ Current_github.Api.cmdliner $ repo))
+  Cmd.v
+    info
+    Term.(term_result (
+      const main
+      $ Current.Config.cmdliner
+      $ Current_web.cmdliner
+      $ Capnp_setup.cmdliner
+      $ submission_service
+      $ Current_github.Api.cmdliner
+      $ repo
+      $ Prometheus_unix.opts))
 
 let () = exit @@ Cmd.eval cmd

--- a/service/metrics.ml
+++ b/service/metrics.ml
@@ -10,7 +10,7 @@ let master =
 
 let update () =
   let open Opam_repo_ci in
-  let n_per_status = Index.n_per_status () in
+  let n_per_status = Index.get_n_per_status () in
   Gauge.set (master "not_started") (float_of_int n_per_status.not_started);
   Gauge.set (master "pending") (float_of_int n_per_status.pending);
   Gauge.set (master "failed") (float_of_int n_per_status.failed);

--- a/service/metrics.ml
+++ b/service/metrics.ml
@@ -1,0 +1,17 @@
+open Prometheus
+
+let namespace = "opamrepoci"
+let subsystem = "pipeline"
+
+let master =
+  let help = "Number of PRs by state" in
+  Gauge.v_label ~label_name:"state" ~help ~namespace ~subsystem
+    "pr_state_total"
+
+let update () =
+  let open Opam_repo_ci in
+  let n_per_status = Index.n_per_status () in
+  Gauge.set (master "not_started") (float_of_int n_per_status.not_started);
+  Gauge.set (master "pending") (float_of_int n_per_status.pending);
+  Gauge.set (master "failed") (float_of_int n_per_status.failed);
+  Gauge.set (master "passed") (float_of_int n_per_status.passed)


### PR DESCRIPTION
This PR exposes metrics showing the number of PRs per status, as shown in the example graph below. This is kept track of using `Status_cache`, and I don't know if this always corresponds to reality in terms of emptying the cache etc. It would be possible to do database reads instead but this would be a little more expensive.

<img width="755" alt="Screenshot 2023-11-22 at 13 50 46" src="https://github.com/ocurrent/opam-repo-ci/assets/13054139/cc597cfb-03f7-42a1-ac1e-5153dfae6f02">
