### PR TITLE
Decrement PR status metric when PR is merged

### DIFF
--- a/lib/index.ml
+++ b/lib/index.ml
@@ -241,7 +241,7 @@ let set_active_refs ~repo (refs : (string * string) list) =
     (* Set difference: find refs that have been removed by merging *)
     let removed_refs =
       List.filter
-        (fun k -> not @@ List.exists ((=) k) refs)
+        (fun k -> not @@ List.mem k refs)
         old_refs
     in
     List.iter (fun (_, hash) ->

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -240,7 +240,9 @@ let set_active_refs ~repo (refs : (string * string) list) =
   |> Option.iter (fun old_refs ->
     (* Set difference: find refs that have been removed by merging *)
     let removed_refs =
-      List.filter (fun k -> List.exists ((!=) k) refs) old_refs
+      List.filter
+        (fun k -> not @@ List.exists ((=) k) refs)
+        old_refs
     in
     List.iter (fun (_, hash) ->
       Status_cache.remove


### PR DESCRIPTION
Corrects https://github.com/ocurrent/opam-repo-ci/pull/247, which did not decrement the status counters when a PR was merged and removed from the active refs list. This led to old PR statuses being kept track of in the metrics.