### PR TITLE
Add metric for the number of handled PRs

### DIFF
--- a/lib/index.mli
+++ b/lib/index.mli
@@ -54,6 +54,8 @@ type n_per_status_t = { not_started : int; pending : int; failed : int; passed :
 
 val get_n_per_status : unit -> n_per_status_t
 
+val get_n_handled : unit -> int
+
 val get_full_hash : owner:string -> name:string -> string -> (string, [> `Ambiguous | `Unknown | `Invalid]) result
 (** [get_full_hash ~owner ~name short_hash] returns the full hash for [short_hash]. *)
 

--- a/service/metrics.ml
+++ b/service/metrics.ml
@@ -8,10 +8,16 @@ let master =
   Gauge.v_label ~label_name:"state" ~help ~namespace ~subsystem
     "pr_state_total"
 
+let handled_prs =
+  let help = "Number of PRs closed or merged" in
+  Gauge.v ~help ~namespace ~subsystem "pr_handled"
+
 let update () =
   let open Opam_repo_ci in
   let n_per_status = Index.get_n_per_status () in
   Gauge.set (master "not_started") (float_of_int n_per_status.not_started);
   Gauge.set (master "pending") (float_of_int n_per_status.pending);
   Gauge.set (master "failed") (float_of_int n_per_status.failed);
-  Gauge.set (master "passed") (float_of_int n_per_status.passed)
+  Gauge.set (master "passed") (float_of_int n_per_status.passed);
+  let n_handled = Index.get_n_handled () in
+  Gauge.set handled_prs (float_of_int n_handled)


### PR DESCRIPTION
PRs are handled on `opam-repository` by either being closed or being merged. There does not yet exist the functionality to distinguish these two cases.