### PR TITLE
Update SHA in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ocaml/opam:debian-12-ocaml-4.14@sha256:7690cb8be43e8d7a7451ac729d7a8ac5e57ca1acb82ab502cb96bce3d59a46ec AS build
+FROM ocaml/opam:debian-12-ocaml-4.14@sha256:5bfa9a370555ea63799c80944416d2555699c5af07457e8600e18dce062f22bf AS build
 RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && opam init --reinit -ni
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto graphviz m4 pkg-config libsqlite3-dev libgmp-dev libffi-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard cf93548ddc4f36b87b006f4858fac7ae73ccaa0f && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 3bbee80e94dc3ed2534cffac1ac7fadab3569b69 && opam update
 COPY --chown=opam \
 	ocurrent/current_docker.opam \
 	ocurrent/current_github.opam \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,6 @@
-FROM ocaml/opam:debian-12-ocaml-4.14@sha256:7690cb8be43e8d7a7451ac729d7a8ac5e57ca1acb82ab502cb96bce3d59a46ec AS build
+FROM ocaml/opam:debian-12-ocaml-4.14@sha256:5bfa9a370555ea63799c80944416d2555699c5af07457e8600e18dce062f22bf AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev libffi-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard cf93548ddc4f36b87b006f4858fac7ae73ccaa0f && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 3bbee80e94dc3ed2534cffac1ac7fadab3569b69 && opam update
 COPY --chown=opam \
 	ocurrent/current_rpc.opam \
 	/src/ocurrent/


### PR DESCRIPTION
The previous SHA pointed specifically to an ARM64 build so the `Dockerfile` only worked on ARM64.  However, it should point to the multi-architecture manifest digest so it can be built on other architectures.  This command gives the multi-architecture SHA:

```
docker buildx imagetools inspect ocaml/opam:debian-12-ocaml-4.14
```