### PR TITLE
Jobs per PR metric

### DIFF
--- a/lib/index.ml
+++ b/lib/index.ml
@@ -20,8 +20,6 @@ type t = {
 
 type job_state = [`Not_started | `Active | `Failed of string | `Passed | `Aborted ] [@@deriving show]
 
-type build_status = [ `Not_started | `Pending | `Failed | `Passed ]
-
 let or_fail label x =
   match x with
   | Sqlite3.Rc.OK -> ()
@@ -110,8 +108,19 @@ module Metrics = struct
   let inc_n_handled n = n_handled := !n_handled + n
 end
 
-module Status_cache = struct
-  let cache : (string * string * string, build_status * int) Hashtbl.t = Hashtbl.create 1_000
+type build_status = [ `Not_started | `Pending | `Failed | `Passed ]
+
+module Commit_info_cache = struct
+  type key = string * string * string
+
+  type elt = {
+    build_status : build_status;
+    n_jobs : int
+  }
+
+  let empty_elt = { build_status = `Not_started; n_jobs = 0 }
+
+  let cache : (key, elt) Hashtbl.t = Hashtbl.create 1_000
   let cache_max_size = 1_000_000
 
   let add ~owner ~name ~hash status =
@@ -122,34 +131,47 @@ module Status_cache = struct
     let key = (owner, name, hash) in
     (* Decrement existing status if it exists *)
     Hashtbl.find_opt cache key
-    |> Option.iter (fun x -> fst x |> Metrics.modify_n_per_status (fun x -> x - 1));
+    |> Option.iter (fun x -> Metrics.modify_n_per_status (fun x -> x - 1) x.build_status);
     (* Increment new status *)
-    Metrics.modify_n_per_status (fun x -> x + 1) (fst status);
+    Metrics.modify_n_per_status (fun x -> x + 1) status.build_status;
     Hashtbl.add cache key status
 
   let find ~owner ~name ~hash =
     Hashtbl.find_opt cache (owner, name, hash)
     |> function
       | Some s -> s
-      | None -> `Not_started, 0
+      | None -> empty_elt
 
-  let find_build_status ~owner ~name ~hash = fst @@ find ~owner ~name ~hash
+  let find_build_status ~owner ~name ~hash = (find ~owner ~name ~hash).build_status
 
-  let find_n_jobs ~owner ~name ~hash = snd @@ find ~owner ~name ~hash
+  let find_n_jobs ~owner ~name ~hash = (find ~owner ~name ~hash).n_jobs
 
   let remove ~owner ~name ~hash =
     let key = (owner, name, hash) in
     Hashtbl.find_opt cache key
     |> Option.iter (fun status ->
-      Metrics.modify_n_per_status (fun x -> x - 1) (fst status);
+      Metrics.modify_n_per_status (fun x -> x - 1) status.build_status;
       Hashtbl.remove cache key)
+
+  let get_jobs_per_ref ~owner ~name refs =
+    Hashtbl.fold
+      (fun (owner', name', hash) status acc ->
+        if String.equal owner owner' && String.equal name name' then
+          List.find_opt (fun (_, hash') -> String.equal hash hash') refs
+          |> function
+          | None -> acc
+          | Some (ref, _) -> (ref, status.n_jobs) :: acc
+        else acc)
+      cache
+      []
 end
 
-let get_build_status = Status_cache.find_build_status
+let get_build_status = Commit_info_cache.find_build_status
 
-let get_n_jobs = Status_cache.find_n_jobs
+let get_n_jobs = Commit_info_cache.find_n_jobs
 
-let set_status = Status_cache.add
+let set_status ~owner ~name ~hash (build_status, n_jobs) =
+  Commit_info_cache.add ~owner ~name ~hash Commit_info_cache.{build_status; n_jobs}
 
 let get_n_per_status () = !Metrics.n_per_status
 
@@ -247,7 +269,7 @@ let get_active_accounts () = !active_accounts
 let active_refs : (string * string) list Repo_map.t ref = ref Repo_map.empty
 
 let set_active_refs ~repo (refs : (string * string) list) =
-  (* Remove statuses from Status_cache corresponding to removed refs *)
+  (* Remove statuses from Commit_info_cache corresponding to removed refs *)
   Repo_map.find_opt repo !active_refs
   |> Option.iter (fun old_refs ->
     (* Set difference: find removed refs that have been merged or closed *)
@@ -258,7 +280,7 @@ let set_active_refs ~repo (refs : (string * string) list) =
     in
     Metrics.inc_n_handled (List.length removed_refs);
     List.iter (fun (_, hash) ->
-      Status_cache.remove
+      Commit_info_cache.remove
         ~owner:repo.Current_github.Repo_id.owner
         ~name:repo.name ~hash)
         removed_refs);
@@ -266,3 +288,10 @@ let set_active_refs ~repo (refs : (string * string) list) =
 
 let get_active_refs repo =
   Repo_map.find_opt repo !active_refs |> Option.value ~default:[]
+
+let get_jobs_per_ref repo =
+  let active_refs = get_active_refs repo in
+  Commit_info_cache.get_jobs_per_ref
+    ~owner:repo.Current_github.Repo_id.owner
+    ~name:repo.name
+    active_refs

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -84,3 +84,6 @@ val set_active_refs : repo:Current_github.Repo_id.t -> (string * string) list ->
 val get_active_refs : Current_github.Repo_id.t -> (string * string) list
 (** [get_active_refs repo] is the entries last set for [repo] with [set_active_refs], or
     [] if this repository isn't known. *)
+
+val get_jobs_per_ref : Current_github.Repo_id.t -> (string * int) list
+(** [get_jobs_per_ref repo] is the number of jobs run for each ref in [repo]. *)

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -35,20 +35,27 @@ val get_job : owner:string -> name:string -> hash:string -> variant:string -> (s
 
 val get_job_ids: owner:string -> name:string -> hash:string -> string list
 
-val get_status:
+val get_build_status:
   owner:string ->
   name:string ->
   hash:string ->
   build_status
-(** [get_status ~owner ~name ~hash] is the latest status for this combination. *)
+(** [get_build_status ~owner ~name ~hash] is the latest status for this combination. *)
+
+val get_n_jobs:
+  owner:string ->
+  name:string ->
+  hash:string ->
+  int
+(** [get_n_jobs ~owner ~name ~hash] is the latest number of jobs for this combination. *)
 
 val set_status:
   owner:string ->
   name:string ->
   hash:string ->
-  build_status ->
+  build_status * int ->
   unit
-(** [set_status ~owner ~name ~hash build_status] sets the latest status for this combination. *)
+(** [set_status ~owner ~name ~hash build_status] sets the latest status and number of jobs for this combination. *)
 
 type n_per_status_t = { not_started : int; pending : int; failed : int; passed : int }
 

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -60,7 +60,7 @@ let make_commit ~engine ~owner ~name hash =
       let open Commit.Status in
       release_param_caps ();
       let response, results = Service.Response.create Results.init_pointer in
-      Index.get_status ~owner ~name ~hash
+      Index.get_build_status ~owner ~name ~hash
       |> (function
           | `Not_started -> Results.status_set results NotStarted
           | `Pending -> Results.status_set results Pending

--- a/service/local.ml
+++ b/service/local.ml
@@ -5,10 +5,13 @@ open Lwt.Infix
 
 module Github = Current_github
 
+let opam_repository = { Github.Repo_id.owner = "ocaml"; name = "opam-repository" }
+
 let () =
   Memtrace.trace_if_requested ~context:"opam-repo-ci-local" ();
   Unix.putenv "DOCKER_BUILDKIT" "1";
   Prometheus_unix.Logging.init ();
+  Metrics.set_primary_repo opam_repository;
   Prometheus.CollectorRegistry.(register_pre_collect default) Metrics.update
 
 let main config mode capnp_address submission_uri api repo_id prometheus_config =
@@ -32,8 +35,6 @@ let main config mode capnp_address submission_uri api repo_id prometheus_config 
   end
 
 (* Command-line parsing *)
-
-let opam_repository = { Github.Repo_id.owner = "ocaml"; name = "opam-repository" }
 
 open Cmdliner
 

--- a/service/metrics.mli
+++ b/service/metrics.mli
@@ -1,0 +1,8 @@
+(* val namespace : string
+val subsystem : string
+val master : string -> Prometheus.Gauge.t
+val handled_prs : Prometheus.Gauge.t
+val jobs_per_pr : string -> Prometheus.Gauge.t *)
+(* val primary_repo : Current_github.Repo_id.t option ref *)
+val set_primary_repo : Current_github.Repo_id.t -> unit
+val update : unit -> unit

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -14,17 +14,17 @@ let test_simple () =
   Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
                                      VALUES ('test', x'00', 'job1', x'01', 1, x'02', '2019-11-01 9:00', '2019-11-01 9:01', '2019-11-01 9:02', 0)";
   Index.set_active_refs ~repo ["master", hash];
-  Index.set_status ~owner ~name ~hash `Pending;
+  Index.set_status ~owner ~name ~hash (`Pending, 0);
   Index.record ~repo ~hash @@ Index.Job_map.of_list [ "analysis", Some "job1"; "alpine", None ];
   Alcotest.(check (list string)) "Repos" ["name"] @@ Index.list_repos owner;
   Alcotest.(check (list (pair string string))) "Refs" ["master", hash] @@ Index.get_active_refs repo;
   Alcotest.(check jobs) "Jobs" ["alpine", `Not_started; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
   Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
                                      VALUES ('test', x'01', 'job2', x'01', 0, x'21', '2019-11-01 9:03', '2019-11-01 9:04', '2019-11-01 9:05', 0)";
-  Index.set_status ~owner ~name ~hash `Failed;
+  Index.set_status ~owner ~name ~hash (`Failed, 0);
   Index.record ~repo ~hash @@ Index.Job_map.of_list [ "analysis", Some "job1"; "alpine", Some "job2" ];
   Alcotest.(check jobs) "Jobs" ["alpine", `Failed "!"; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
-  Index.set_status ~owner ~name ~hash `Passed;
+  Index.set_status ~owner ~name ~hash (`Passed, 0);
   Index.record ~repo ~hash @@ Index.Job_map.of_list [ "analysis", Some "job1" ];
   Alcotest.(check jobs) "Jobs" ["analysis", `Passed] @@ Index.get_jobs ~owner ~name hash
 


### PR DESCRIPTION
Surfaces the number of jobs spawned for each PR, as a guide for how much of the server resources each is taking.

Example Grafana bar chart:
<img width="709" alt="Screenshot 2023-12-08 at 16 24 57" src="https://github.com/ocurrent/opam-repo-ci/assets/13054139/2147d1d4-ac1d-4741-95ca-5831a9054f99">
