### PR TITLE
Local development pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,18 @@ Status: **experimental**
 
 This is an [OCurrent][] pipeline that tests submissions to [opam-repository][].
 
-To test locally you will need:
-
-1. A [personal access token][] from GitHub.
-2. A `submission.cap` for an [OCluster][] build cluster.
-
-Run the `opam-repo-ci-local` command
-(you might need to increase the limit on the number of open files):
+To test locally you will need a local copy of the [opam-repository][] Git repo. Run the `opam-repo-ci-local` command (you might need to increase the limit on the number of open files):
 
 ```
 ulimit -n 102400
 dune exec -- opam-repo-ci-local \
   --confirm harmless \
-  --submission-service submission.cap \
-  --github-token-file token \
+  --repo REPO-PATH \
+  --branch BRANCH-NAME \
   --capnp-address tcp:127.0.0.1:5001
 ```
+
+Here `REPO-PATH` is the relative or absolute path to your copy of `opam-repository`, and `BRANCH-NAME` is the name of the branch containing the changes you want to make, relative to the master branch.
 
 Browse to http://localhost:8080 to see the web UI.
 You can either set the confirm threshold (at the bottom of the web page) to allow all builds to start,
@@ -33,7 +29,7 @@ depend on this one and test them too.
 ### Web UI
 
 The public web front-end is a separate process.
-It needs a `.cap` file to connect to the engine.
+It needs a `.cap` capability file to connect to the engine.
 If you have the file for the real service, you can use that.
 If you're testing the engine locally (as shown above), you can use the `./capnp-secrets/opam-repo-ci-admin.cap`
 that it writes out.

--- a/lib/buildkit_syntax.ml
+++ b/lib/buildkit_syntax.ml
@@ -1,0 +1,27 @@
+(* From `docker manifest inspect docker/dockerfile:experimental` *)
+let hash_for = function
+  | `X86_64 ->
+      "sha256:8c69d118cfcd040a222bea7f7d57c6156faa938cb61b47657cd65343babc3664"
+  | `I386 ->
+      "sha256:8c69d118cfcd040a222bea7f7d57c6156faa938cb61b47657cd65343babc3664"
+  | `Aarch64 ->
+      "sha256:d9ced99b409ddb781c245c7c11f72566f940424fc3883ac0b5c5165f402e5a09"
+  | `Aarch32 ->
+      "sha256:5f502d5a34f8cd1780fde9301b69488e9c0cfcecde2d673b6bff19aa4979fdfc"
+  | `Ppc64le ->
+      "sha256:c0fe20821d527e147784f7e782513880bf31b0060b2a7da7a94582ecde81c85f"
+  | `S390x ->
+      "sha256:e2b9c21cc1d0067116c572db562f80de9b0c7a654ac41f094651a724408beafc"
+
+let add arch =
+  let hash =
+    hash_for
+      (match arch with
+      | `X86_64 | `I386 -> `X86_64
+      | `Aarch64 | `Aarch32 -> `Aarch64
+      | `Ppc64le -> `Ppc64le
+      | `S390x -> `S390x
+      | `Riscv64 ->
+          failwith "No support for riscv64 in docker/dockerfile:experimental.")
+  in
+  Printf.sprintf "# syntax = docker/dockerfile:experimental@%s\n" hash

--- a/lib/buildkit_syntax.mli
+++ b/lib/buildkit_syntax.mli
@@ -1,0 +1,5 @@
+(** Activate BuildKit experimental syntax. *)
+
+val add : Ocaml_version.arch -> string
+(** [add arch] will activate BuildKit experimental syntax with a hash that will
+    work for that architecture. Defaults to x86_64 if no arch is specified. *)

--- a/lib/cluster_build.mli
+++ b/lib/cluster_build.mli
@@ -1,21 +1,3 @@
-module Spec : sig
-  type t
-
-  val opam :
-    ?revdep:OpamPackage.t ->
-    platform:Platform.t ->
-    lower_bounds:bool ->
-    with_tests:bool ->
-    opam_version:[`V2_0 | `V2_1 | `Dev] ->
-    OpamPackage.t ->
-    t
-end
-
-type base =
-  | Docker of Current_docker.Raw.Image.t
-  | MacOS of string
-  | FreeBSD of string
-
 type t
 
 val config : timeout:int64 -> [ `Submission_f4e8a768b32a7c42 ] Capnp_rpc_lwt.Sturdy_ref.t -> t
@@ -24,7 +6,7 @@ val v :
   t ->
   label:string ->
   spec:Spec.t Current.t ->
-  base:base Current.t ->
+  base:Spec.base Current.t ->
   master:Current_git.Commit.t Current.t ->
   urgent:([`High | `Low] -> bool) option Current.t ->
   Current_git.Commit_id.t Current.t ->
@@ -35,7 +17,7 @@ val list_revdeps :
   platform:Platform.t ->
   opam_version:[`V2_0 | `V2_1 | `Dev] ->
   pkgopt:PackageOpt.t Current.t ->
-  base:base Current.t ->
+  base:Spec.base Current.t ->
   master:Current_git.Commit.t Current.t ->
   after:unit Current.t ->
   Current_git.Commit_id.t Current.t ->

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -1,4 +1,5 @@
 val check :
+  is_macos:bool ->
   master:Current_git.Commit.t Current.t ->
   packages:(OpamPackage.t * Analyse.Analysis.kind) list Current.t ->
   Current_git.Commit.t Current.t ->

--- a/lib/local_build.ml
+++ b/lib/local_build.ml
@@ -1,0 +1,292 @@
+open Current.Syntax
+open Lwt.Infix
+
+module Git = Current_git
+module Raw = Current_docker.Raw
+
+(* TODO: Make macOS use docker images *)
+type base =
+  | Docker of Current_docker.Raw.Image.t
+  | MacOS of string
+  | FreeBSD of string
+
+let base_to_string = function
+  | Docker img -> Current_docker.Raw.Image.hash img
+  | MacOS base -> base
+  | FreeBSD base -> base
+
+let ( >>!= ) = Lwt_result.bind
+
+module Spec = struct
+  type package = OpamPackage.t
+
+  let package_to_yojson x = `String (OpamPackage.to_string x)
+
+  type opam_build = {
+    revdep : package option;
+    with_tests : bool;
+    lower_bounds : bool;
+    opam_version : [`V2_0 | `V2_1 | `Dev];
+  } [@@deriving to_yojson]
+
+  type list_revdeps = {
+    opam_version : [`V2_0 | `V2_1 | `Dev];
+  } [@@deriving to_yojson]
+
+  type ty = [
+    | `Opam of [ `Build of opam_build | `List_revdeps of list_revdeps ] * package
+  ] [@@deriving to_yojson]
+
+  type t = {
+    platform : Platform.t;
+    ty : ty;
+  }
+
+  let opam ?revdep ~platform ~lower_bounds ~with_tests ~opam_version pkg =
+    let ty = `Opam (`Build { revdep; lower_bounds; with_tests; opam_version }, pkg) in
+    { platform; ty }
+
+  let pp_pkg ?revdep f pkg =
+    match revdep with
+    | Some revdep -> Fmt.pf f "%s with %s" (OpamPackage.to_string revdep) (OpamPackage.to_string pkg)
+    | None -> Fmt.string f (OpamPackage.to_string pkg)
+
+  let pp_opam_version = function
+    | `V2_0 -> "2.0"
+    | `V2_1 -> "2.1"
+    | `Dev -> "dev"
+
+  let pp_ty f = function
+    | `Opam (`List_revdeps {opam_version}, pkg) ->
+        Fmt.pf f "list revdeps of %s, using opam %s" (OpamPackage.to_string pkg)
+          (pp_opam_version opam_version)
+    | `Opam (`Build { revdep; lower_bounds; with_tests; opam_version }, pkg) ->
+      let action = if with_tests then "test" else "build" in
+      Fmt.pf f "%s %a%s, using opam %s" action (pp_pkg ?revdep) pkg
+        (if lower_bounds then ", lower-bounds" else "")
+        (pp_opam_version opam_version)
+
+  let pp_summary f = function
+    | `Opam (`List_revdeps _, _) -> Fmt.string f "Opam list revdeps"
+    | `Opam (`Build _, _) -> Fmt.string f "Opam project build"
+end
+
+let checkout_pool = Current.Pool.create ~label:"git-clone" 1
+
+module Commit_lock = struct
+  let locks = Hashtbl.create 1000
+
+  let rec with_lock ~job commit variant fn =
+    let key = (Current_git.Commit.hash commit, variant) in
+    match Hashtbl.find_opt locks key with
+    | Some lock ->
+        Current.Job.log job "Waiting for a similar build to finish...";
+        lock >>= fun () -> with_lock ~job commit variant fn
+    | None ->
+        let finished, set_finished = Lwt.wait () in
+        Hashtbl.add locks key finished;
+        Lwt.finalize fn (fun () ->
+            Hashtbl.remove locks key;
+            Lwt.wakeup set_finished ();
+            Lwt.return_unit)
+end
+
+module Builder = struct
+  type t = {
+    docker_context : string option;
+    pool : unit Current.Pool.t;
+    build_timeout : Duration.t;
+  }
+
+  let build { docker_context; pool; build_timeout } ~dockerfile source =
+    Current_docker.Raw.build (`Git source) ~dockerfile ~docker_context ~pool
+      ~timeout:build_timeout ~pull:false
+
+  let pull { docker_context; pool = _; build_timeout = _ } ~arch tag =
+    let arch =
+      if Ocaml_version.arch_is_32bit arch then
+        Some (Ocaml_version.to_docker_arch arch)
+      else None
+    in
+    Current_docker.Raw.pull ?arch tag ~docker_context
+
+  let run { docker_context; pool; build_timeout = _ } ~args img =
+    Current_docker.Raw.run img ~docker_context ~pool ~args
+end
+
+module Op = struct
+  type nonrec t = {
+    config : Builder.t;
+    master : Current_git.Commit.t;
+    urgent : ([`High | `Low] -> bool) option;
+    base : base;
+  }
+
+  let id = "ci-build"
+  let dockerignore = ".git"
+
+  module Key = struct
+    type t = {
+      commit : Current_git.Commit.t; (* The source code to build and test *)
+      branch : string;
+      label : string; (* A unique ID for this build within the commit *)
+    }
+
+    let to_json { commit; branch; label } =
+      `Assoc
+        [
+          ("commit", `String (Current_git.Commit.hash commit));
+          ("branch", `String branch);
+          ("label", `String label);
+        ]
+
+    let digest t = Yojson.Safe.to_string (to_json t)
+  end
+
+  module Value = struct
+    type t = {
+      ty : Spec.ty;
+      variant : Variant.t; (* Added as a comment in the Dockerfile *)
+    }
+
+    let to_json { ty; variant } =
+      `Assoc
+        [
+          ("op", Spec.ty_to_yojson ty);
+          ("variant", Variant.to_yojson variant);
+        ]
+
+    let digest t = Yojson.Safe.to_string (to_json t)
+  end
+
+  module Outcome = Current.Unit
+
+  let or_raise = function Ok () -> () | Error (`Msg m) -> raise (Failure m)
+
+  let run { config; master = _; urgent = _; base } job
+      { Key.commit; label = _; branch = _ } { Value.ty; variant } =
+    let { Builder.docker_context; pool; build_timeout } = config in
+    let build_spec =
+      let base = base_to_string base in
+      match ty with
+      | `Opam (`List_revdeps { opam_version }, pkg) ->
+          Opam_build.revdeps ~for_docker:true ~opam_version ~base ~variant ~pkg
+      | `Opam (`Build { revdep; lower_bounds; with_tests; opam_version }, pkg) ->
+          Opam_build.spec ~for_docker:true ~opam_version ~base ~variant ~revdep ~lower_bounds ~with_tests ~pkg
+    in
+    match base with
+    | MacOS _s -> failwith "local macos docker not supported"
+    | FreeBSD _s -> failwith "local freebsd docker not supported"
+    | Docker base ->
+        let make_dockerfile ~for_user =
+          (if for_user then "" else Buildkit_syntax.add (Variant.arch variant))
+          ^ Obuilder_spec.Docker.dockerfile_of_spec ~buildkit:(not for_user)
+              ~os:`Unix build_spec
+        in
+        Current.Job.write job
+          (Fmt.str "@[<v>Base: %a@,%a@]@." Raw.Image.pp base Spec.pp_summary ty);
+        Current.Job.write job
+          (Fmt.str
+             "@.To reproduce locally:@.@.cd $(mktemp -d)@.%a@.cat > Dockerfile \
+              <<'END-OF-DOCKERFILE'@.\o033[34m%s\o033[0mEND-OF-DOCKERFILE@.docker \
+              build .@.END-REPRO-BLOCK@.@."
+             Current_git.Commit_id.pp_user_clone
+             (Current_git.Commit.id commit)
+             (make_dockerfile ~for_user:true));
+        let dockerfile = make_dockerfile ~for_user:false in
+        Current.Job.start ~timeout:build_timeout ~pool job
+          ~level:Current.Level.Average
+        >>= fun () ->
+        Commit_lock.with_lock ~job commit variant @@ fun () ->
+        Current_git.with_checkout ~pool:checkout_pool ~job commit @@ fun dir ->
+        Current.Job.write job
+          (Fmt.str "Writing BuildKit Dockerfile:@.%s@." dockerfile);
+        Bos.OS.File.write Fpath.(dir / "Dockerfile") (dockerfile ^ "\n")
+        |> or_raise;
+        Bos.OS.File.write Fpath.(dir / ".dockerignore") dockerignore |> or_raise;
+        let cmd =
+          Raw.Cmd.docker ~docker_context
+          @@ [ "build"; "--"; Fpath.to_string dir ]
+        in
+        let pp_error_command f = Fmt.string f "Docker build" in
+        Current.Process.exec ~cancellable:true ~pp_error_command ~job cmd
+
+  let pp f ({ Key.commit; label; branch }, _) =
+    Fmt.pf f "test %s %a (%s)" branch Current_git.Commit.pp commit label
+
+  let auto_cancel = true
+  let latched = true
+end
+
+module BC = Current_cache.Generic(Op)
+
+(* let v t ~label ~spec ~base ~master ~urgent commit =
+  Current.component "%s" label |>
+  let> { Spec.platform; ty } = spec
+  and> base = base
+  and> commit = commit
+  and> master = master
+  and> urgent = urgent in
+  let t = { Op.config = t; master; urgent; base } in
+  let { Platform.pool; variant; label = _ } = platform in
+  BC.run t { Op.Key.pool; commit; variant; ty } ()
+  |> Current.Primitive.map_result (Result.map ignore) *)
+
+let v ~label ~spec ~master ~urgent ~base ~docker_context ~pool ~build_timeout commit branch =
+  Current.component "%s" label |>
+  let> {Spec.platform; ty} = spec
+  and> base in
+  let t = {Op.config = { Builder.docker_context; pool; build_timeout }; master; urgent; base } in
+  BC.run t {commit; branch; label} { ty; variant = platform.variant }
+  |> Current.Primitive.map_result (Result.map ignore)
+
+(* let build ~platforms ~spec ~repo commit =
+  Current.component "build"
+  |> let> { Spec.variant; ty; label } = spec
+      and> commit
+      and> platforms
+      and> repo in
+      match
+        List.find_opt
+          (fun p -> Variant.equal p.Platform.variant variant)
+          platforms
+      with
+      | Some { Platform.builder; variant; base; _ } ->
+          BC.run builder
+            { Op.Key.commit; repo; label }
+            { Op.Value.base; ty; variant }
+      | None ->
+          (* We can only get here if there is a bug. If the set of platforms changes, [Analyse] should recalculate. *)
+          let msg =
+            Fmt.str "BUG: variant %a is not a supported platform" Variant.pp
+              variant
+          in
+          Current_incr.const (Error (`Msg msg), None) *)
+
+(* let list_revdeps t ~platform ~opam_version ~pkgopt ~base ~master ~after commit =
+  Current.component "list revdeps" |>
+  let> {PackageOpt.pkg; urgent; has_tests = _} = pkgopt
+  and> base = base
+  and> commit = commit
+  and> master = master
+  and> () = after in
+  let t = { Op.config = t; master; urgent; base } in
+  let { Platform.pool; variant; label = _ } = platform in
+  let ty = `Opam (`List_revdeps {Spec.opam_version}, pkg) in
+  BC.run t { Op.Key.pool; commit; variant; ty } ()
+  |> Current.Primitive.map_result (Result.map (fun output ->
+      String.split_on_char '\n' output |>
+      List.fold_left (fun acc -> function
+          | "" -> acc
+          | revdep ->
+              let revdep = OpamPackage.of_string revdep in
+              if OpamPackage.equal pkg revdep then
+                acc (* NOTE: opam list --recursive --depends-on <pkg> also returns <pkg> itself *)
+              else
+                OpamPackage.Set.add revdep acc
+        ) OpamPackage.Set.empty
+    )) *)
+
+(* let build_with_docker ~analysis ty =
+  Current.with_context analysis @@ fun () ->
+   *)

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -1,0 +1,62 @@
+(* TODO: Make macOS use docker images *)
+type base =
+  | Docker of Current_docker.Raw.Image.t
+  | MacOS of string
+  | FreeBSD of string
+
+let base_to_string = function
+  | Docker img -> Current_docker.Raw.Image.hash img
+  | MacOS base -> base
+  | FreeBSD base -> base
+
+type package = OpamPackage.t
+
+let package_to_yojson x = `String (OpamPackage.to_string x)
+
+type opam_build = {
+  revdep : package option;
+  with_tests : bool;
+  lower_bounds : bool;
+  opam_version : [`V2_0 | `V2_1 | `Dev];
+} [@@deriving to_yojson]
+
+type list_revdeps = {
+  opam_version : [`V2_0 | `V2_1 | `Dev];
+} [@@deriving to_yojson]
+
+type ty = [
+  | `Opam of [ `Build of opam_build | `List_revdeps of list_revdeps ] * package
+] [@@deriving to_yojson]
+
+type t = {
+  platform : Platform.t;
+  ty : ty;
+}
+
+let opam ?revdep ~platform ~lower_bounds ~with_tests ~opam_version pkg =
+  let ty = `Opam (`Build { revdep; lower_bounds; with_tests; opam_version }, pkg) in
+  { platform; ty }
+
+let pp_pkg ?revdep f pkg =
+  match revdep with
+  | Some revdep -> Fmt.pf f "%s with %s" (OpamPackage.to_string revdep) (OpamPackage.to_string pkg)
+  | None -> Fmt.string f (OpamPackage.to_string pkg)
+
+let pp_opam_version = function
+  | `V2_0 -> "2.0"
+  | `V2_1 -> "2.1"
+  | `Dev -> "dev"
+
+let pp_ty f = function
+  | `Opam (`List_revdeps {opam_version}, pkg) ->
+      Fmt.pf f "list revdeps of %s, using opam %s" (OpamPackage.to_string pkg)
+        (pp_opam_version opam_version)
+  | `Opam (`Build { revdep; lower_bounds; with_tests; opam_version }, pkg) ->
+    let action = if with_tests then "test" else "build" in
+    Fmt.pf f "%s %a%s, using opam %s" action (pp_pkg ?revdep) pkg
+      (if lower_bounds then ", lower-bounds" else "")
+      (pp_opam_version opam_version)
+
+let pp_summary f = function
+  | `Opam (`List_revdeps _, _) -> Fmt.string f "Opam list revdeps"
+  | `Opam (`Build _, _) -> Fmt.string f "Opam project build"

--- a/service/local.ml
+++ b/service/local.ml
@@ -1,37 +1,19 @@
 (* Utility program for testing the CI pipeline locally. *)
 
-open Capnp_rpc_lwt
-open Lwt.Infix
-
-module Github = Current_github
-
-let opam_repository = { Github.Repo_id.owner = "ocaml"; name = "opam-repository" }
-
 let () =
   Memtrace.trace_if_requested ~context:"opam-repo-ci-local" ();
-  Unix.putenv "DOCKER_BUILDKIT" "1";
-  Prometheus_unix.Logging.init ();
-  Metrics.set_primary_repo opam_repository;
-  Prometheus.CollectorRegistry.(register_pre_collect default) Metrics.update
+  Unix.putenv "DOCKER_BUILDKIT" "1"
 
-let main config mode capnp_address submission_uri api repo_id is_macos prometheus_config =
+let main config mode repo branch is_macos =
   Lwt_main.run begin
-    Capnp_setup.run capnp_address >>= fun (vat, rpc_engine_resolver) ->
-    let repo = (api, repo_id) in
-    let ocluster = Capnp_rpc_unix.Vat.import_exn vat submission_uri in
-    let engine = Current.Engine.create ~config (Pipeline.local_test ~is_macos ~ocluster repo) in
-    rpc_engine_resolver |> Option.iter (fun r -> Capability.resolve_ok r (Api_impl.make_ci ~engine));
+    let repo = Current_git.Local.v (Result.get_ok @@ Fpath.of_string repo) in
+    let engine = Current.Engine.create ~config (Pipeline.local_test ~is_macos repo branch) in
     let routes = Current_web.routes engine in
     let site = Current_web.Site.(v ~has_role:allow_all) ~name:"opam-repo-ci-local" routes in
-    let prometheus =
-      List.map
-        (Lwt.map @@ Result.ok)
-        (Prometheus_unix.serve prometheus_config)
-    in
     Lwt.choose ([
       Current.Engine.thread engine;
       Current_web.run ~mode site;
-    ] @ prometheus)
+    ])
   end
 
 (* Command-line parsing *)
@@ -39,20 +21,20 @@ let main config mode capnp_address submission_uri api repo_id is_macos prometheu
 open Cmdliner
 
 let repo =
-  Arg.value @@
-  Arg.opt Github.Repo_id.cmdliner opam_repository @@
+  Arg.required @@
+  Arg.opt Arg.(some dir) None @@
   Arg.info
-    ~doc:"The GitHub repository (owner/name) to monitor."
+    ~doc:"The path of the local Git repository to monitor"
     ~docv:"REPO"
     ["repo"]
 
-let submission_service =
+let branch =
   Arg.required @@
-  Arg.opt Arg.(some Capnp_rpc_unix.sturdy_uri) None @@
+  Arg.opt Arg.(some string) None @@
   Arg.info
-    ~doc:"The submission.cap file for the build scheduler service."
-    ~docv:"FILE"
-    ["submission-service"]
+    ~doc:"The name of the branch that contains your changes"
+    ~docv:"BRANCH"
+    ["branch"]
 
 (* https://github.com/ocurrent/opam-repo-ci/issues/260 *)
 let is_macos =
@@ -64,18 +46,19 @@ let is_macos =
     ["macos"]
 
 let cmd =
-  let doc = "Test opam-repo-ci on a local Git clone" in
+  let doc = "Test opam-repo-ci on a local Git repository" in
   let info = Cmd.info "opam-repo-ci-local" ~doc in
   Cmd.v info
     Term.(term_result (
       const main
       $ Current.Config.cmdliner
       $ Current_web.cmdliner
-      $ Capnp_setup.cmdliner
-      $ submission_service
-      $ Current_github.Api.cmdliner
       $ repo
+<<<<<<< HEAD
       $ is_macos
       $ Prometheus_unix.opts))
+=======
+      $ branch))
+>>>>>>> bef800d (Lint job running locally)
 
 let () = exit @@ Cmd.eval cmd

--- a/service/local.ml
+++ b/service/local.ml
@@ -8,7 +8,8 @@ let () =
   Unix.putenv "DOCKER_BUILDKIT" "1";
   Prometheus_unix.Logging.init ()
 
-let main config mode is_macos capnp_address repo branch =
+let main config mode is_macos capnp_address repo branch level =
+  Logs.set_level level;
   Lwt_main.run begin
     let repo = Current_git.Local.v (Result.get_ok @@ Fpath.of_string repo) in
     let engine = Current.Engine.create ~config (Pipeline.local_test_pr ~is_macos repo branch) in
@@ -63,6 +64,7 @@ let cmd =
       $ is_macos
       $ Capnp_setup.cmdliner
       $ repo
-      $ branch))
+      $ branch
+      $ Logs_cli.level ()))
 
 let () = exit @@ Cmd.eval cmd

--- a/service/node.ml
+++ b/service/node.ml
@@ -19,7 +19,6 @@ let flatten t ~map ~merge ~empty =
   let ctx = { label = Current.return "" ; map ; merge ; empty } in
   t ~ctx
 
-
 let empty ~ctx = Current.return ctx.empty
 
 let action kind job ~ctx = ctx.map.f ~label:ctx.label kind job
@@ -34,7 +33,6 @@ let dir ~label = leaf ~label:(label ^ status_sep)
 
 let dir_dyn ~label t ~ctx =
   t ~ctx: { ctx with label = let+ prefix = ctx.label and+ label = label in prefix ^ label ^ status_sep }
-
 
 let of_list children ~ctx =
   List.fold_left
@@ -60,7 +58,6 @@ let actioned_branch_dyn ~label action children ~ctx =
   let+ t = leaf_dyn ~label action ~ctx
   and+ ts = dir_dyn ~label (of_list children) ~ctx
   in ctx.merge t ts
-
 
 let map_reduce ordered ?collapse_key ~map ~merge ~empty input =
   let+ lst = Current.list_map ordered ?collapse_key map input in

--- a/service/node.mli
+++ b/service/node.mli
@@ -28,7 +28,7 @@ val actioned_branch : label:string -> 'a t -> 'a t list -> 'a t
 (** [actioned_branch ~label action children] is a branch node with an action directly attached to the node itself. *)
 
 val actioned_branch_dyn : label:string Current.t -> 'a t -> 'a t list -> 'a t
-(** Same as [actionned_branch], but with a dynamic [label]. *)
+(** Same as [actioned_branch], but with a dynamic [label]. *)
 
 val branch : label:string -> 'a t list -> 'a t
 (** [branch ~label children] is a branch node. *)

--- a/service/node.mli
+++ b/service/node.mli
@@ -1,13 +1,21 @@
+(** Alternative node representation used to minimise memory load.
+
+    Context in https://github.com/ocurrent/opam-repo-ci/pull/161.  *)
+
 type kind = [`Built | `Analysed | `Linted]
 
 type 'a t
 (** A tree of ocurrent results. *)
 
 type 'a f = { f: 'x . label: string Current.t -> kind -> 'x Current.t -> 'a Current.t }
-(** A mapping function for the leaves of the tree: It's quantified over its input ['x Current.t] as the actions can produce anything, so [f] will only be able to extract their metadata with [job_id] and/or [Current.state]. *)
+(** A mapping function for the leaves of the tree: It's quantified over
+    its input ['x Current.t] as the actions can produce anything, so [f]
+    will only be able to extract their metadata with [job_id] and/or [Current.state]. *)
 
 val flatten : 'a t -> map: 'a f -> merge: ('a -> 'a -> 'a) -> empty: 'a -> 'a Current.t
-(** [flatten t ~map ~merge ~empty] applies [map] to every [action] leaves of the tree, then fold all the results with the [merge] function (which should be associative, commutative, with [empty] as its zero). *)
+(** [flatten t ~map ~merge ~empty] applies [map] to every [action] leaves
+    of the tree, then fold all the results with the [merge] function
+    (which should be associative, commutative, with [empty] as its zero). *)
 
 val empty : 'a t
 (** An [empty] tree with no leaf. *)
@@ -25,7 +33,8 @@ val action : [ `Built | `Analysed | `Linted ] -> 'a Current.t -> 'b t
 (** [action kind job] is a leaf that will be mapped by [flatten]. *)
 
 val actioned_branch : label:string -> 'a t -> 'a t list -> 'a t
-(** [actioned_branch ~label action children] is a branch node with an action directly attached to the node itself. *)
+(** [actioned_branch ~label action children] is a branch node with an action
+    directly attached to the node itself. *)
 
 val actioned_branch_dyn : label:string Current.t -> 'a t -> 'a t list -> 'a t
 (** Same as [actioned_branch], but with a dynamic [label]. *)
@@ -36,8 +45,14 @@ val branch : label:string -> 'a t list -> 'a t
 val branch_dyn : label:string Current.t -> 'a t list -> 'a t
 (** Same as [branch], but with a dynamic [label]. *)
 
-val list_map : (module Current_term.S.ORDERED with type t = 'a) -> ?collapse_key:string -> ('a Current.t -> 'b t) -> 'a list Current.t -> 'b t
-(** [list_map ord ?collapse_key f lst] is the dynamic list [Current.list_map ord ?collapse_key f lst], except that its output is fixed to [empty] until the input [lst] is successful. You must ensure that the status of the input [lst] is reported elsewhere. *)
+val list_map :
+  (module Current_term.S.ORDERED with type t = 'a) ->
+  ?collapse_key:string -> ('a Current.t -> 'b t) ->
+  'a list Current.t -> 'b t
+(** [list_map ord ?collapse_key f lst] is the dynamic list
+    [Current.list_map ord ?collapse_key f lst], except that its output is
+    fixed to [empty] until the input [lst] is successful. You must ensure
+    that the status of the input [lst] is reported elsewhere. *)
 
 val bool_map : (unit -> 'a t) -> bool Current.t -> 'a t
 
@@ -45,4 +60,5 @@ val collapse : key:string -> value:string -> input:_ Current.t -> 'a t -> 'a t
 (** [collapse ~key ~value ~input t] performs [Current.collapse]. *)
 
 val job_id : 'a Current.t -> Current.job_id option Current.t
-(** [job_id t] is the job id associated with the ocurrent term [t], or [None] if the job hasn't been created yet (or if [t] is not an ocurrent primitive). *)
+(** [job_id t] is the job id associated with the ocurrent term [t], or [None]
+    if the job hasn't been created yet (or if [t] is not an ocurrent primitive). *)

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -367,7 +367,6 @@ module Build_with = struct
       Node.leaf ~label:"(lint)" (Node.action `Linted lint);
       Node.branch ~label:"compilers" (compilers ~build);
       Node.branch ~label:"distributions" (linux_distributions ~build);
-      Node.branch ~label:"extras" (extras ~build);
     ]
 end
 

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -113,7 +113,7 @@ let get_significant_available_pkg = function
   | _, {Analyse.Analysis.kind = Deleted | Unavailable | UnsignificantlyChanged; _} -> None
 
 module Build_with_cluster = struct
-  let build ~ocluster ~analysis ~pkgs ~master ~source ~opam_version ~lower_bounds ~revdeps label variant =
+  let build_with_cluster ~ocluster ~analysis ~pkgs ~master ~source ~opam_version ~lower_bounds ~revdeps label variant =
     let arch = Variant.arch variant in
     let pool = Conf.pool_of_arch variant in (* ocluster-pool eg linux-x86_64 *)
     let platform = {Platform.label; pool; variant} in
@@ -276,7 +276,7 @@ module Build_with_cluster = struct
   let v ~ocluster ~analysis ~lint ~master source =
     let pkgs = Current.map (fun x -> Analyse.Analysis.packages x
       |> List.filter_map get_significant_available_pkg) analysis in
-    let build = build ~ocluster ~analysis ~pkgs ~master ~source in
+    let build = build_with_cluster ~ocluster ~analysis ~pkgs ~master ~source in
     [
       Node.leaf ~label:"(lint)" (Node.action `Linted lint);
       Node.branch ~label:"compilers" (compilers ~build);
@@ -488,8 +488,8 @@ let local_test ~is_macos repo pr_branch () =
   in
   let builds =
     Node.root
-      ([Node.leaf ~label:"(analysis)" (Node.action `Analysed latest_analysis)])
-      (* :: build_with_cluster ~ocluster ~analysis ~lint ~master commit_id) *)
+      (Node.leaf ~label:"(analysis)" (Node.action `Analysed latest_analysis)
+      :: build_with_cluster ~ocluster ~analysis ~lint ~master commit_id)
   in
   ignore builds;
   lint

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -260,9 +260,9 @@ module Build_with = struct
             Node.leaf ~label:"lower-bounds" action
           else
             Node.empty
-        (* and revdeps =
+        and revdeps =
           if revdeps then test_revdeps ~ocluster ~opam_version ~master ~base ~platform ~pkgopt source ~after:image
-          else Node.empty *)
+          else Node.empty
         in
         let label = Current.map OpamPackage.to_string pkg in
         ignore revdeps;
@@ -270,7 +270,7 @@ module Build_with = struct
         Node.actioned_branch_dyn ~label build [
           tests;
           lower_bounds_check;
-          (* revdeps; *)
+          revdeps;
         ]
       )
     |> (fun x -> Node.branch ~label [x])

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -575,7 +575,7 @@ let v ~is_macos ~ocluster ~app () =
 let set_index_local ~repo gref hash =
   let+ repo
   and+ hash in
-  Index.(set_active_accounts @@ Account_set.singleton "local");
+  Index.(set_active_accounts @@ Account_set.singleton repo.Github.Repo_id.owner);
   Index.set_active_refs ~repo [(gref, hash)]
 
 let local_test_pr ~is_macos repo pr_branch () =
@@ -598,7 +598,9 @@ let local_test_pr ~is_macos repo pr_branch () =
       (Node.leaf ~label:"(analysis)" (Node.action `Analysed analysis)
       :: Build_with.docker ~analysis ~lint ~master pr_branch)
   in
-  let dummy_repo = Current.return { Github.Repo_id.owner = "local"; name = "local" } in
+  let dummy_repo =
+    Current.return { Github.Repo_id.owner = "local-owner"; name = "local-repo" }
+  in
   let pr_hash = Current.map Git.Commit.hash pr_branch in
   (let+ _ = set_index_local ~repo:dummy_repo pr_gref pr_hash
   and+ result = summarise ~repo:dummy_repo ~hash:pr_hash builds in

--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -1,9 +1,11 @@
 val local_test :
+  is_macos:bool ->
   ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
   Current_github.Api.Repo.t -> unit -> unit Current.t
 (** [local_test ~ocluster repo] is a pipeline that tests GitHub repository [repo] as the CI would. *)
 
 val v :
+  is_macos:bool ->
   ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
   app:Current_github.App.t ->
   unit -> unit Current.t

--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -1,8 +1,6 @@
-val local_test :
-  is_macos:bool ->
-  ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
-  Current_github.Api.Repo.t -> unit -> unit Current.t
-(** [local_test ~ocluster repo] is a pipeline that tests GitHub repository [repo] as the CI would. *)
+val local_test : is_macos:bool -> Current_git.Local.t -> string -> unit -> unit Current.t
+(** [local_test repo branch] is a pipeline that tests
+    branch [branch] on the local Git repository at path [repo]. *)
 
 val v :
   is_macos:bool ->

--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -1,4 +1,4 @@
-val local_test : is_macos:bool -> Current_git.Local.t -> string -> unit -> unit Current.t
+val local_test_pr : is_macos:bool -> Current_git.Local.t -> string -> unit -> unit Current.t
 (** [local_test repo branch] is a pipeline that tests
     branch [branch] on the local Git repository at path [repo]. *)
 


### PR DESCRIPTION
`opam-repo-ci` currently has a development pipeline ([service/local.ml](https://github.com/ocurrent/opam-repo-ci/blob/master/service/local.ml)) that is nominally local, but in fact requires:
1. A GitHub repository along with GitHub authentication
2. Access to a cluster to run jobs

This PR fixes problem (1) by accessing a local Git repository through its file path, and problem (2) by using Docker to run jobs locally. This is a significant step towards supporting integration testing of the pipeline.

Various quality-of-life changes are also made to the original pipeline, for example to share code between the two. The `cluster_build` cache was originally a `Current_cache.Generic`, but as the value in the key-value pair was empty it can simply be specialised to a `Current_cache.Make`, which better represents its purpose (as far as I understand).

Depends on PR https://github.com/ocurrent/opam-repo-ci/pull/257.