### PR TITLE
Support running on MacOS

### DIFF
--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -1,4 +1,5 @@
 val check :
+  is_macos:bool ->
   master:Current_git.Commit.t Current.t ->
   packages:(OpamPackage.t * Analyse.Analysis.kind) list Current.t ->
   Current_git.Commit.t Current.t ->

--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -1,9 +1,11 @@
 val local_test :
+  is_macos:bool ->
   ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
   Current_github.Api.Repo.t -> unit -> unit Current.t
 (** [local_test ~ocluster repo] is a pipeline that tests GitHub repository [repo] as the CI would. *)
 
 val v :
+  is_macos:bool ->
   ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
   app:Current_github.App.t ->
   unit -> unit Current.t


### PR DESCRIPTION
Fixes https://github.com/ocurrent/opam-repo-ci/issues/260.

A particular function in the linting step causes problems on MacOS, detailed in the issue above.

This PR creates a separate function that moves the opam process from a preemptive thread to the main thread. We prefer to use the original non-blocking function on Linux as it prevents an unresponsive service.

The user must specify that they are running MacOS with an optional command-line argument, `--macos`.

(Ideally we should fix the bug at the source but it looks like it'd be complete hell, so this is good enough™.)