### PR TITLE
Unvendor opam and set lower bounds to 2.2.0~beta1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,7 +14,3 @@
 	path = ocaml-version
 	url = https://github.com/ocurrent/ocaml-version.git
 	branch = master
-[submodule "opam"]
-	path = opam
-	url = https://github.com/ocaml/opam.git
-	branch = master

--- a/opam-repo-ci-service.opam
+++ b/opam-repo-ci-service.opam
@@ -32,15 +32,8 @@ depends: [
   "capnp-rpc-lwt" {>= "0.8.0"}
   "capnp-rpc-unix" {>= "0.8.0"}
   "opam-repo-ci-api"
-  # "opam-state" {>= "2.1.0~beta4"}
-  # "opam-format" {>= "2.1.0~beta4"}
-  "sha" # needed for the opam vendor
-  "re" # needed for the opam vendor
-  "ocamlgraph" # needed for the opam vendor
-  "cppo" # needed for the opam vendor
-  "spdx_licenses" # needed for the opam vendor
-  "jsonm" # needed for the opam vendor
-  "swhid_core" # needed for the opam vendor
+  "opam-state" {>= "2.2.0~beta1"}
+  "opam-format" {>= "2.2.0~beta1"}
   "opam-file-format" {>= "2.1.2"}
   "sexplib" {>= "v0.14.0"}
   "conf-libev"


### PR DESCRIPTION
Opam was vendored to get access to 2.2.0 functionality in https://github.com/ocurrent/opam-repo-ci/pull/186. With the 2.2.0~beta1 release we can unvendor it and simply set the dependencies.