### PR TITLE
Cram testing for lint check

### DIFF
--- a/lib/integration_test.ml
+++ b/lib/integration_test.ml
@@ -1,0 +1,16 @@
+open Current.Syntax
+
+(* Which part of the pipeline should be tested *)
+type t =
+  | Lint
+
+let check_lint ~test_config lint =
+  let f () =
+    let+ result = Current.catch lint in
+    begin match result with
+      | Ok () -> Printf.printf "Ok ()\n"
+      | Error (`Msg s) -> Printf.printf "Error \"%s\"\n" s
+    end;
+    exit 0
+  in
+  Option.iter (fun _ -> ignore @@ f ()) test_config

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -3,8 +3,9 @@
     for example relating to the format of [.opam] and [dune] files.
     This job is run locally. *)
 val check :
+  ?test_config:Integration_test.t ->
   host_os:string ->
   master:Current_git.Commit.t Current.t ->
-  packages:(OpamPackage.t * Analyse.Analysis.kind) list Current.t ->
+  packages:(OpamPackage.t * Analyse.Analysis.data) list Current.t ->
   Current_git.Commit.t Current.t ->
   unit Current.t

--- a/service/build.ml
+++ b/service/build.ml
@@ -250,7 +250,7 @@ let with_cluster ~ocluster ~analysis ~lint ~master source =
     Node.branch ~label:"extras" (extras ~build);
   ]
 
-let with_docker ~analysis ~lint ~master source =
+let with_docker ~host_arch ~analysis ~lint ~master source =
   let module Builder : Build_intf.S = Local_build in
   let pkgs =
     Current.map (fun x -> Analyse.Analysis.packages x
@@ -259,6 +259,6 @@ let with_docker ~analysis ~lint ~master source =
   let build = build (module Builder) ~analysis ~pkgs ~master ~source in
   [
     Node.leaf ~label:"(lint)" (Node.action `Linted lint);
-    Node.branch ~label:"compilers" (compilers ~arch:Conf.host_arch ~build);
-    Node.branch ~label:"distributions" (linux_distributions ~arch:Conf.host_arch ~build);
+    Node.branch ~label:"compilers" (compilers ~arch:host_arch ~build);
+    Node.branch ~label:"distributions" (linux_distributions ~arch:host_arch ~build);
   ]

--- a/service/build.mli
+++ b/service/build.mli
@@ -11,6 +11,7 @@ val with_cluster :
 (** [with_docker ~analysis ~lint ~master commit] runs all the necessary builds
     for [commit] relative to [master] using local Docker containers. *)
 val with_docker :
+  host_arch:Ocaml_version.arch ->
   analysis:Opam_repo_ci.Analyse.Analysis.t Current.t ->
   lint:unit Current.t ->
   master:Current_git.Commit.t Current.t ->

--- a/service/capnp_setup.ml
+++ b/service/capnp_setup.ml
@@ -7,21 +7,21 @@ let or_die = function
   | Ok x -> x
   | Error `Msg m -> failwith m
 
-let run ?listen_address = function
+let run ?listen_address ~secret_key ~cap_file = function
   | None -> Lwt.return (Capnp_rpc_unix.client_only_vat (), None)
   | Some public_address ->
     let config =
       Capnp_rpc_unix.Vat_config.create
         ~public_address
-        ~secret_key:(`File Conf.Capnp.secret_key)
+        ~secret_key:(`File secret_key)
         (Option.value listen_address ~default:public_address)
     in
     let rpc_engine, rpc_engine_resolver = Capability.promise () in
     let service_id = Capnp_rpc_unix.Vat_config.derived_id config "ci" in
     let restore = Capnp_rpc_net.Restorer.single service_id rpc_engine in
     Capnp_rpc_unix.serve config ~restore >>= fun vat ->
-    Capnp_rpc_unix.Cap_file.save_service vat service_id Conf.Capnp.cap_file |> or_die;
-    Logs.app (fun f -> f "Wrote capability reference to %S" Conf.Capnp.cap_file);
+    Capnp_rpc_unix.Cap_file.save_service vat service_id cap_file |> or_die;
+    Logs.app (fun f -> f "Wrote capability reference to %S" cap_file);
     Lwt.return (vat, Some rpc_engine_resolver)
 
 open Cmdliner

--- a/service/capnp_setup.mli
+++ b/service/capnp_setup.mli
@@ -5,6 +5,8 @@ type config = Capnp_rpc_unix.Network.Location.t option
 
 val run :
   ?listen_address:Capnp_rpc_unix.Network.Location.t ->
+  secret_key:string ->
+  cap_file:string ->
   config ->
   (Capnp_rpc_unix.Vat.t * Opam_repo_ci_api.Raw.Service.CI.t Capability.resolver option) Lwt.t
 (** [run (Some public_address)] runs a Cap'n Proto service advertising its

--- a/service/local.ml
+++ b/service/local.ml
@@ -8,19 +8,39 @@ let () =
   Unix.putenv "DOCKER_BUILDKIT" "1";
   Prometheus_unix.Logging.init ()
 
-let setup_capnp ~engine ~listen_address capnp_address =
-  Capnp_setup.run ~listen_address capnp_address >|= fun (_, rpc_engine_resolver) ->
-  Option.iter (fun r -> Capability.resolve_ok r (Api_impl.make_ci ~engine)) rpc_engine_resolver
+(* Test configuration for integration testing *)
+let get_test_config lint_only =
+  if lint_only then
+    Some Opam_repo_ci.Integration_test.Lint
+  else
+    None
 
-let main config mode capnp_address repo branch level =
+let setup_capnp ~engine ~listen_address secret_key cap_file capnp_address =
+  Capnp_setup.run ~listen_address ~secret_key ~cap_file capnp_address
+  >|= fun (_, rpc_engine_resolver) ->
+  Option.iter
+    (fun r -> Capability.resolve_ok r (Api_impl.make_ci ~engine))
+    rpc_engine_resolver
+
+let main config mode capnp_address repo branch lint_only level =
   Logs.set_level level;
   Lwt_main.run begin
     let repo = Current_git.Local.v (Result.get_ok @@ Fpath.of_string repo) in
-    let engine = Current.Engine.create ~config (Pipeline.local_test_pr repo branch) in
-    let listen_address = Capnp_rpc_unix.Network.Location.tcp ~host:"0.0.0.0" ~port:Conf.Capnp.internal_port in
-    setup_capnp ~engine ~listen_address capnp_address >>= fun () ->
+    let engine =
+      Current.Engine.create ~config
+        (Pipeline.local_test_pr ?test_config:(get_test_config lint_only) repo branch)
+    in
+    let listen_address =
+      Capnp_rpc_unix.Network.Location.tcp
+        ~host:"0.0.0.0" ~port:Conf.Capnp.internal_port
+    in
+    setup_capnp ~engine ~listen_address Conf.Capnp.secret_key
+      Conf.Capnp.cap_file capnp_address >>= fun () ->
     let routes = Current_web.routes engine in
-    let site = Current_web.Site.(v ~has_role:allow_all) ~name:"opam-repo-ci-local" routes in
+    let site =
+      Current_web.Site.(v
+        ~has_role:allow_all) ~name:"opam-repo-ci-local" routes
+    in
     Lwt.choose ([
       Current.Engine.thread engine;
       Current_web.run ~mode site;
@@ -47,6 +67,14 @@ let branch =
     ~docv:"BRANCH"
     ["branch"]
 
+let lint_only =
+  Arg.value @@
+  Arg.flag @@
+  Arg.info
+    ~doc:"Run lint check and then exit. Used for integration testing"
+    ~docv:"LINT_ONLY"
+    ["lint-only"]
+
 let cmd =
   let doc = "Test opam-repo-ci on a local Git repository" in
   let info = Cmd.info "opam-repo-ci-local" ~doc in
@@ -58,6 +86,7 @@ let cmd =
       $ Capnp_setup.cmdliner
       $ repo
       $ branch
+      $ lint_only
       $ Logs_cli.level ()))
 
 let () = exit @@ Cmd.eval cmd

--- a/service/main.ml
+++ b/service/main.ml
@@ -128,7 +128,8 @@ let main config mode app capnp_address github_auth submission_uri prometheus_con
   Logs.set_level level;
   Lwt_main.run begin
     let listen_address = Capnp_rpc_unix.Network.Location.tcp ~host:"0.0.0.0" ~port:Conf.Capnp.internal_port in
-    Capnp_setup.run ~listen_address capnp_address >>= fun (vat, rpc_engine_resolver) ->
+    Capnp_setup.run ~listen_address ~secret_key:Conf.Capnp.secret_key
+      ~cap_file:Conf.Capnp.cap_file capnp_address >>= fun (vat, rpc_engine_resolver) ->
     let ocluster = Capnp_rpc_unix.Vat.import_exn vat submission_uri in
     let engine = Current.Engine.create ~config (Pipeline.v ~ocluster ~app) in
     Option.iter (fun r -> Capability.resolve_ok r (Api_impl.make_ci ~engine)) rpc_engine_resolver;

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -192,7 +192,7 @@ let summarise ~repo ~hash builds =
   in
   summary
 
-let test_pr ~ocluster ~master ~head =
+let test_pr ~ocluster ~master head =
   let repo = Current.map Current_github.Api.Commit.repo_id head in
   let commit_id = Current.map Github.Api.Commit.id head in
   let hash = Current.map Git.Commit_id.hash commit_id in
@@ -200,13 +200,7 @@ let test_pr ~ocluster ~master ~head =
   let latest_analysis = analyse ~master src in
   let analysis = latest_analysis |> latch ~label:"analysis" (* ignore errors from a rerun *) in
   let lint =
-    let packages =
-      Current.map (fun x ->
-        List.map (fun (pkg, {Analyse.Analysis.kind; has_tests = _}) ->
-          (pkg, kind))
-          (Analyse.Analysis.packages x))
-        analysis
-    in
+    let packages = Current.map Analyse.Analysis.packages analysis in
     Lint.check ~host_os:Conf.host_os ~master ~packages src
   in
   let builds =
@@ -227,7 +221,7 @@ let test_repo ~ocluster ~push_status repo =
   let master = latch ~label:"master" master in  (* Don't cancel builds while fetching updates to this *)
   let prs = set_active_refs ~repo prs in
   prs |> Current.list_iter ~collapse_key:"pr" (module Github.Api.Commit) @@ fun head ->
-    test_pr ~ocluster ~master ~head
+    test_pr ~ocluster ~master head
     |> github_status_of_state ~head
     |> (if push_status then github_set_statuses ~head
         else Current.ignore_value)
@@ -254,26 +248,20 @@ let set_index_local ~repo gref hash =
   Index.(set_active_accounts @@ Account_set.singleton repo.Github.Repo_id.owner);
   Index.set_active_refs ~repo [(gref, hash)]
 
-let local_test_pr repo pr_branch () =
+let local_test_pr ?test_config repo pr_branch () =
   let master = Git.Local.commit_of_ref repo "refs/heads/master" in
   let pr_gref = Printf.sprintf "refs/heads/%s" pr_branch in
   let pr_branch = Git.Local.commit_of_ref repo pr_gref in
   let pr_branch_id = Current.map Git.Commit.id pr_branch in
   let analysis = analyse ~master pr_branch in
   let lint =
-    let packages =
-      Current.map (fun x ->
-        List.map (fun (pkg, {Analyse.Analysis.kind; has_tests = _}) ->
-          (pkg, kind))
-          (Analyse.Analysis.packages x))
-        analysis
-    in
-    Lint.check ~host_os:Conf.host_os ~master ~packages pr_branch
+    let packages = Current.map Analyse.Analysis.packages analysis in
+    Lint.check ?test_config ~host_os:Conf.host_os ~master ~packages pr_branch
   in
   let builds =
     Node.root
       (Node.leaf ~label:"(analysis)" (Node.action `Analysed analysis)
-      :: Build.with_docker ~analysis ~lint ~master pr_branch_id)
+      :: Build.with_docker ~host_arch:Conf.host_arch ~analysis ~lint ~master pr_branch_id)
   in
   let dummy_repo =
     Current.return { Github.Repo_id.owner = "local-owner"; name = "local-repo" }

--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -8,4 +8,4 @@ val v :
 
 (** [local_test repo branch] is a pipeline that tests branch [branch] on
     the local Git repository at path [repo] using local Docker containers. *)
-val local_test_pr : Current_git.Local.t -> string -> unit -> unit Current.t
+val local_test_pr : ?test_config:Opam_repo_ci.Integration_test.t -> Current_git.Local.t -> string -> unit -> unit Current.t

--- a/test/dune
+++ b/test/dune
@@ -3,4 +3,12 @@
  (package opam-repo-ci-service)
  (libraries opam_repo_ci alcotest alcotest-lwt ppx_deriving_yojson.runtime)
  (preprocess
-  (pps ppx_deriving.eq ppx_deriving_yojson)))
+  (pps ppx_deriving.eq ppx_deriving_yojson))
+ (deps
+  (glob_files ./patches/*)))
+
+(cram
+ (deps
+  %{bin:opam-repo-ci-local}
+  ./scripts/setup_repo.sh
+  (glob_files ./patches/*)))

--- a/test/lint-correct.t
+++ b/test/lint-correct.t
@@ -2,5 +2,5 @@
   $ git apply "patches/b-correct.patch"
   $ git add .
   $ git commit -qm b-correct
-  $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --port=8080
+  $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --no-web-server
   Ok ()

--- a/test/lint-correct.t
+++ b/test/lint-correct.t
@@ -1,0 +1,6 @@
+  $ sh "scripts/setup_repo.sh"
+  $ git apply "patches/b-correct.patch"
+  $ git add .
+  $ git commit -qm b-correct
+  $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --port=8080
+  Ok ()

--- a/test/lint-incorrect-opam.t
+++ b/test/lint-incorrect-opam.t
@@ -7,5 +7,5 @@ Tests the following:
   $ git apply "patches/b-incorrect-opam.patch"
   $ git add .
   $ git commit -qm b-incorrect-opam
-  $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --port=8081
+  $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --no-web-server
   Error "2 errors"

--- a/test/lint-incorrect-opam.t
+++ b/test/lint-incorrect-opam.t
@@ -1,0 +1,11 @@
+Tests the following:
+- [b.0.0.1] is missing the [author] field
+- [b.0.0.2] has an extra unknown field
+- [b.0.0.3] is correct
+
+  $ sh "scripts/setup_repo.sh"
+  $ git apply "patches/b-incorrect-opam.patch"
+  $ git add .
+  $ git commit -qm b-incorrect-opam
+  $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --port=8081
+  Error "2 errors"

--- a/test/lint-name-collision.t
+++ b/test/lint-name-collision.t
@@ -1,0 +1,9 @@
+Tests the package name collision detection by adding four versions
+of a package [a_1] that conflicts with the existing [a-1] package
+
+  $ sh "scripts/setup_repo.sh"
+  $ git apply "patches/a_1-name-collision.patch"
+  $ git add .
+  $ git commit -qm a_1-name-collision
+  $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --port=8082
+  Error "4 errors"

--- a/test/lint-name-collision.t
+++ b/test/lint-name-collision.t
@@ -5,5 +5,5 @@ of a package [a_1] that conflicts with the existing [a-1] package
   $ git apply "patches/a_1-name-collision.patch"
   $ git add .
   $ git commit -qm a_1-name-collision
-  $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --port=8082
+  $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --no-web-server
   Error "4 errors"

--- a/test/patches/a-1.patch
+++ b/test/patches/a-1.patch
@@ -1,0 +1,50 @@
+From 87954d1c1f2ca2814915ca0e46405f34ae697032 Mon Sep 17 00:00:00 2001
+From: benmandrew <benmandrew@gmail.com>
+Date: Wed, 21 Feb 2024 13:25:54 +0100
+Subject: [PATCH] a
+
+---
+ packages/a-1/a-1.0.0.1/opam | 12 ++++++++++++
+ packages/a-1/a-1.0.0.2/opam | 12 ++++++++++++
+ 2 files changed, 24 insertions(+)
+ create mode 100644 packages/a-1/a-1.0.0.1/opam
+ create mode 100644 packages/a-1/a-1.0.0.2/opam
+
+diff --git a/packages/a-1/a-1.0.0.1/opam b/packages/a-1/a-1.0.0.1/opam
+new file mode 100644
+index 0000000..58229e8
+--- /dev/null
++++ b/packages/a-1/a-1.0.0.1/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []
+diff --git a/packages/a-1/a-1.0.0.2/opam b/packages/a-1/a-1.0.0.2/opam
+new file mode 100644
+index 0000000..58229e8
+--- /dev/null
++++ b/packages/a-1/a-1.0.0.2/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []
+-- 
+2.43.0

--- a/test/patches/a_1-name-collision.patch
+++ b/test/patches/a_1-name-collision.patch
@@ -1,0 +1,90 @@
+From 87954d1c1f2ca2814915ca0e46405f34ae697032 Mon Sep 17 00:00:00 2001
+From: benmandrew <benmandrew@gmail.com>
+Date: Wed, 21 Feb 2024 13:25:54 +0100
+Subject: [PATCH] a
+
+---
+ packages/a_1/a_1.0.0.1/opam | 12 ++++++++++++
+ packages/a_1/a_1.0.0.2/opam | 12 ++++++++++++
+ packages/a_1/a_1.0.1.0/opam | 12 ++++++++++++
+ packages/a_1/a_1.0.1.1/opam | 12 ++++++++++++
+ 2 files changed, 24 insertions(+)
+ create mode 100644 packages/a_1/a_1.0.0.1/opam
+ create mode 100644 packages/a_1/a_1.0.0.2/opam
+ create mode 100644 packages/a_1/a_1.0.1.0/opam
+ create mode 100644 packages/a_1/a_1.0.1.1/opam
+
+diff --git a/packages/a_1/a_1.0.0.1/opam b/packages/a_1/a_1.0.0.1/opam
+new file mode 100644
+index 0000000..58229e8
+--- /dev/null
++++ b/packages/a_1/a_1.0.0.1/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []
+diff --git a/packages/a_1/a_1.0.0.2/opam b/packages/a_1/a_1.0.0.2/opam
+new file mode 100644
+index 0000000..58229e8
+--- /dev/null
++++ b/packages/a_1/a_1.0.0.2/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []
+diff --git a/packages/a_1/a_1.0.1.0/opam b/packages/a_1/a_1.0.1.0/opam
+new file mode 100644
+index 0000000..58229e8
+--- /dev/null
++++ b/packages/a_1/a_1.0.1.0/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []
+diff --git a/packages/a_1/a_1.0.1.1/opam b/packages/a_1/a_1.0.1.1/opam
+new file mode 100644
+index 0000000..58229e8
+--- /dev/null
++++ b/packages/a_1/a_1.0.1.1/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []
+-- 
+2.43.0

--- a/test/patches/b-correct.patch
+++ b/test/patches/b-correct.patch
@@ -1,0 +1,76 @@
+From 00dbea20350d84b089ff1c1014252fa31babcb2a Mon Sep 17 00:00:00 2001
+From: benmandrew <benmandrew@gmail.com>
+Date: Mon, 19 Feb 2024 14:25:05 +0100
+Subject: [PATCH] b
+
+---
+ packages/b/b.0.0.1/opam | 13 +++++++++++++
+ packages/b/b.0.0.2/opam | 13 +++++++++++++
+ packages/b/b.0.0.3/opam | 13 +++++++++++++
+ 3 files changed, 39 insertions(+)
+ create mode 100644 packages/b/b.0.0.1/opam
+ create mode 100644 packages/b/b.0.0.2/opam
+ create mode 100644 packages/b/b.0.0.3/opam
+
+diff --git a/packages/b/b.0.0.1/opam b/packages/b/b.0.0.1/opam
+new file mode 100644
+index 0000000..69040f4
+--- /dev/null
++++ b/packages/b/b.0.0.1/opam
+@@ -0,0 +1,14 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: [
++  "a-1" {>= "0.0.1"}
++]
+diff --git a/packages/b/b.0.0.2/opam b/packages/b/b.0.0.2/opam
+new file mode 100644
+index 0000000..1581508
+--- /dev/null
++++ b/packages/b/b.0.0.2/opam
+@@ -0,0 +1,14 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: [
++  "a-1" {>= "0.0.2"}
++]
+diff --git a/packages/b/b.0.0.3/opam b/packages/b/b.0.0.3/opam
+new file mode 100644
+index 0000000..5ec1dc4
+--- /dev/null
++++ b/packages/b/b.0.0.3/opam
+@@ -0,0 +1,14 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: [
++  "a-1" {< "0.0.2"}
++]
+-- 
+2.43.0

--- a/test/patches/b-incorrect-opam.patch
+++ b/test/patches/b-incorrect-opam.patch
@@ -1,0 +1,76 @@
+From 00dbea20350d84b089ff1c1014252fa31babcb2a Mon Sep 17 00:00:00 2001
+From: benmandrew <benmandrew@gmail.com>
+Date: Mon, 19 Feb 2024 14:25:05 +0100
+Subject: [PATCH] b
+
+---
+ packages/b/b.0.0.1/opam | 13 +++++++++++++
+ packages/b/b.0.0.2/opam | 13 +++++++++++++
+ packages/b/b.0.0.3/opam | 13 +++++++++++++
+ 3 files changed, 39 insertions(+)
+ create mode 100644 packages/b/b.0.0.1/opam
+ create mode 100644 packages/b/b.0.0.2/opam
+ create mode 100644 packages/b/b.0.0.3/opam
+
+diff --git a/packages/b/b.0.0.1/opam b/packages/b/b.0.0.1/opam
+new file mode 100644
+index 0000000..69040f4
+--- /dev/null
++++ b/packages/b/b.0.0.1/opam
+@@ -0,0 +1,13 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: [
++  "a-1" {>= "0.0.1"}
++]
+diff --git a/packages/b/b.0.0.2/opam b/packages/b/b.0.0.2/opam
+new file mode 100644
+index 0000000..1581508
+--- /dev/null
++++ b/packages/b/b.0.0.2/opam
+@@ -0,0 +1,15 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++unknown-field : "Unknown"
++build: []
++depends: [
++  "a-1" {>= "0.0.2"}
++]
+diff --git a/packages/b/b.0.0.3/opam b/packages/b/b.0.0.3/opam
+new file mode 100644
+index 0000000..5ec1dc4
+--- /dev/null
++++ b/packages/b/b.0.0.3/opam
+@@ -0,0 +1,14 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: [
++  "a-1" {< "0.0.2"}
++]
+-- 
+2.43.0

--- a/test/scripts/setup_repo.sh
+++ b/test/scripts/setup_repo.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+mkdir "capnp-secrets"
+git init -q .
+git config --local user.email test@test.com
+git config --local user.name Test
+git checkout -qb master
+git apply "patches/a-1.patch"
+git add .
+git commit -qm a-1
+git checkout -qb new-branch

--- a/test/umask-022.t
+++ b/test/umask-022.t
@@ -1,9 +1,0 @@
-The lint check requires created opam files to have permissions 644.
-
-Requiring the user to change their [umask] is not ideal, it would be better to
-find a way to change the permissions of the files in the cram tests. [chmod]
-works on the files in the test directory, but the [opam-repo-ci-local] binary
-appears to use files copied to a new directory with [umask] permissions.
-
-  $ umask
-  0022

--- a/test/umask-022.t
+++ b/test/umask-022.t
@@ -1,0 +1,9 @@
+The lint check requires created opam files to have permissions 644.
+
+Requiring the user to change their [umask] is not ideal, it would be better to
+find a way to change the permissions of the files in the cram tests. [chmod]
+works on the files in the test directory, but the [opam-repo-ci-local] binary
+appears to use files copied to a new directory with [umask] permissions.
+
+  $ umask
+  0022


### PR DESCRIPTION
Proper integration testing of the `opam-repo-ci-local` binary, replaces #274.

Currently only the lint check is tested, but this will be expanded in later PRs.