### PR TITLE
Add detail to linting error result

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -404,7 +404,9 @@ module Lint = struct
     match errors with
     | [] -> Ok ()
     | [msg] -> Error (`Msg msg)
-    | _::_ -> Error (`Msg (Fmt.str "%d errors" (List.length errors)))
+    | l ->
+      let err_str = String.concat "\n" l in
+      Error (`Msg (Fmt.str "%d errors:\n%s" (List.length errors) err_str))
 
   let pp f _ = Fmt.string f "Lint"
 

--- a/test/lint-incorrect-opam.t
+++ b/test/lint-incorrect-opam.t
@@ -8,4 +8,6 @@ Tests the following:
   $ git add .
   $ git commit -qm b-incorrect-opam
   $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --no-web-server
-  Error "2 errors"
+  Error "2 errors:
+  Error in b.0.0.2:              error  3: File format error in 'unknown-field' at line 11, column 0: Invalid field unknown-field
+  Error in b.0.0.1:            warning 25: Missing field 'authors'"

--- a/test/lint-name-collision.t
+++ b/test/lint-name-collision.t
@@ -6,4 +6,8 @@ of a package [a_1] that conflicts with the existing [a-1] package
   $ git add .
   $ git commit -qm a_1-name-collision
   $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --no-web-server
-  Error "4 errors"
+  Error "4 errors:
+  Warning in a_1.0.1.1: Possible name collision with package 'a-1'
+  Warning in a_1.0.1.0: Possible name collision with package 'a-1'
+  Warning in a_1.0.0.2: Possible name collision with package 'a-1'
+  Warning in a_1.0.0.1: Possible name collision with package 'a-1'"


### PR DESCRIPTION
Allows the integration testing to check for the actual errors, rather than just the number of them.