### PR TITLE
List revdeps integration testing

### DIFF
--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -107,9 +107,9 @@ module Op = struct
       let base = Spec.base_to_string base in
       match ty with
       | `Opam (`List_revdeps { opam_version }, pkg) ->
-          Opam_build.revdeps ~for_docker ~opam_version ~base ~variant ~pkg
+          Opam_build.revdeps ~for_docker ~opam_version ~base ~variant pkg
       | `Opam (`Build { revdep; lower_bounds; with_tests; opam_version }, pkg) ->
-          Opam_build.spec ~for_docker ~opam_version ~base ~variant ~revdep ~lower_bounds ~with_tests ~pkg
+          Opam_build.spec ~for_docker ~opam_version ~base ~variant ~revdep ~lower_bounds ~with_tests pkg
     in
     Current.Job.write job
       (Fmt.str "@.\

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -421,13 +421,10 @@ let get_packages_kind =
       packages)
 
 let check ?test_config ~host_os ~master ~packages src =
-  let res =
-    Current.component "Lint" |>
-    let> src
-    and> packages = get_packages_kind packages
-    and> master in
-    let host_os = if String.equal host_os "macos" then Macos else Other in
-    Lint_cache.run { master } { src; packages } { host_os }
-  in
-  Integration_test.check_lint ~test_config res;
-  res
+  Current.component "Lint" |>
+  let> src
+  and> packages = get_packages_kind packages
+  and> master in
+  let host_os = if String.equal host_os "macos" then Macos else Other in
+  Lint_cache.run { master } { src; packages } { host_os }
+  |> Current.Primitive.map_result @@ Integration_test.check_lint ?test_config

--- a/lib/local_build.mli
+++ b/lib/local_build.mli
@@ -4,6 +4,7 @@
     The job is labelled [label]. [urgent] has no effect, but is included
     to conform with the interface for [Cluster_build]. *)
 val v :
+  ?test_config:Integration_test.t ->
   label:string ->
   spec:Spec.t Current.t ->
   base:Spec.base Current.t ->
@@ -19,6 +20,7 @@ val v :
     The spec is generated on top of [base], and the OCurrent job is run after
     the job specified by [after], making it a dependency. *)
 val list_revdeps :
+  ?test_config:Integration_test.t ->
   variant:Variant.t ->
   opam_version:[ `Dev | `V2_0 | `V2_1 ] ->
   pkgopt:Package_opt.t Current.t ->

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -6,13 +6,14 @@ val spec :
   revdep:OpamPackage.t option ->
   lower_bounds:bool ->
   with_tests:bool ->
-  pkg:OpamPackage.t ->
+  OpamPackage.t ->
   Obuilder_spec.t
 
 val revdeps :
+  ?test_config:Integration_test.t option ->
   for_docker:bool ->
   opam_version:[`V2_0 | `V2_1 | `Dev] ->
   base:string ->
   variant:Variant.t ->
-  pkg:OpamPackage.t ->
+  OpamPackage.t ->
   Obuilder_spec.t

--- a/service/build.mli
+++ b/service/build.mli
@@ -11,6 +11,7 @@ val with_cluster :
 (** [with_docker ~analysis ~lint ~master commit] runs all the necessary builds
     for [commit] relative to [master] using local Docker containers. *)
 val with_docker :
+  ?test_config:Opam_repo_ci.Integration_test.t ->
   host_arch:Ocaml_version.arch ->
   analysis:Opam_repo_ci.Analyse.Analysis.t Current.t ->
   lint:unit Current.t ->

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -261,7 +261,7 @@ let local_test_pr ?test_config repo pr_branch () =
   let builds =
     Node.root
       (Node.leaf ~label:"(analysis)" (Node.action `Analysed analysis)
-      :: Build.with_docker ~host_arch:Conf.host_arch ~analysis ~lint ~master pr_branch_id)
+      :: Build.with_docker ?test_config ~host_arch:Conf.host_arch ~analysis ~lint ~master pr_branch_id)
   in
   let dummy_repo =
     Current.return { Github.Repo_id.owner = "local-owner"; name = "local-repo" }

--- a/test/lint-correct.t
+++ b/test/lint-correct.t
@@ -1,4 +1,5 @@
   $ sh "scripts/setup_repo.sh"
+  $ git checkout -qb new-branch
   $ git apply "patches/b-correct.patch"
   $ git add .
   $ git commit -qm b-correct

--- a/test/lint-incorrect-opam.t
+++ b/test/lint-incorrect-opam.t
@@ -4,6 +4,7 @@ Tests the following:
 - [b.0.0.3] is correct
 
   $ sh "scripts/setup_repo.sh"
+  $ git checkout -qb new-branch
   $ git apply "patches/b-incorrect-opam.patch"
   $ git add .
   $ git commit -qm b-incorrect-opam

--- a/test/lint-name-collision.t
+++ b/test/lint-name-collision.t
@@ -2,6 +2,7 @@ Tests the package name collision detection by adding four versions
 of a package [a_1] that conflicts with the existing [a-1] package
 
   $ sh "scripts/setup_repo.sh"
+  $ git checkout -qb new-branch
   $ git apply "patches/a_1-name-collision.patch"
   $ git add .
   $ git commit -qm a_1-name-collision

--- a/test/patches/a-1-insignificant-change.patch
+++ b/test/patches/a-1-insignificant-change.patch
@@ -1,0 +1,26 @@
+diff --git a/packages/a-1/a-1.0.0.1/opam b/packages/a-1/a-1.0.0.1/opam
+index 5246a83..c17a1ba 100644
+--- a/packages/a-1/a-1.0.0.1/opam
++++ b/packages/a-1/a-1.0.0.1/opam
+@@ -1,7 +1,7 @@
+ opam-version: "2.0"
+ synopsis: "Synopsis"
+ description: "Description"
+-maintainer: "Maintainer"
++maintainer: "Another maintainer"
+ author: "Author"
+ license: "Apache-2.0"
+ homepage: "https://github.com/ocurrent/opam-repo-ci"
+diff --git a/packages/a-1/a-1.0.0.2/opam b/packages/a-1/a-1.0.0.2/opam
+index 5246a83..c018682 100644
+--- a/packages/a-1/a-1.0.0.2/opam
++++ b/packages/a-1/a-1.0.0.2/opam
+@@ -1,7 +1,7 @@
+ opam-version: "2.0"
+ synopsis: "Synopsis"
+ description: "Description"
+-maintainer: "Maintainer"
++maintainer: "Someone else"
+ author: "Author"
+ license: "Apache-2.0"
+ homepage: "https://github.com/ocurrent/opam-repo-ci"

--- a/test/patches/a-1-update.patch
+++ b/test/patches/a-1-update.patch
@@ -1,0 +1,30 @@
+From 87954d1c1f2ca2814915ca0e46405f34ae697032 Mon Sep 17 00:00:00 2001
+From: benmandrew <benmandrew@gmail.com>
+Date: Wed, 15 Mar 2024 17:14:32 +0100
+Subject: [PATCH] a
+
+---
+ packages/a-1/a-1.0.0.3/opam | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+ create mode 100644 packages/a-1/a-1.0.0.1/opam
+
+diff --git a/packages/a-1/a-1.0.0.3/opam b/packages/a-1/a-1.0.0.3/opam
+new file mode 100644
+index 0000000..58229e8
+--- /dev/null
++++ b/packages/a-1/a-1.0.0.3/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []
+-- 
+2.43.0

--- a/test/revdeps-correct.t
+++ b/test/revdeps-correct.t
@@ -1,0 +1,10 @@
+  $ sh "scripts/setup_repo.sh"
+  $ git apply "patches/b-correct.patch"
+  $ git add .
+  $ git commit -qm b-correct
+  $ git checkout -qb new-branch
+  $ git apply "patches/a-1-update.patch"
+  $ git add .
+  $ git commit -qm a-1-update
+  $ opam-repo-ci-local --repo="." --branch=new-branch --revdeps-only
+  Ok ()

--- a/test/revdeps.t
+++ b/test/revdeps.t
@@ -7,4 +7,5 @@
   $ git add .
   $ git commit -qm a-1-update
   $ opam-repo-ci-local --repo="." --branch=new-branch --revdeps-only
-  Ok ()
+  b.0.0.1
+  b.0.0.2

--- a/test/scripts/setup_repo.sh
+++ b/test/scripts/setup_repo.sh
@@ -8,4 +8,3 @@ git checkout -qb master
 git apply "patches/a-1.patch"
 git add .
 git commit -qm a-1
-git checkout -qb new-branch


### PR DESCRIPTION
This tests that the correct reverse depencencies are listed. With our dummy `opam-repository` we add a new version of package `a-1`, on which `b.0.0.1` and `b.0.0.2` depend.

The test currently requires Docker and takes more than 2 minutes to run, as it has to go through the entire Dockerfile. The PR is a draft until this can be improved.

While running, the test pipeline can be monitored on `localhost:8080`.

Other refactoring is also included.