### PR TITLE
Test package name collisions with Levenshtein distance

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -19,4 +19,5 @@
   obuilder-spec
   opam-format
   opam-state
-  opam-repo-ci-api))
+  opam-repo-ci-api
+  mula))

--- a/lib/integration_test.ml
+++ b/lib/integration_test.ml
@@ -1,16 +1,17 @@
-open Current.Syntax
-
 (* Which part of the pipeline should be tested *)
 type t =
   | Lint
 
-let check_lint ~test_config lint =
-  let f () =
-    let+ result = Current.catch lint in
-    begin match result with
-      | Ok () -> Printf.printf "Ok ()\n"
-      | Error (`Msg s) -> Printf.printf "Error \"%s\"\n" s
-    end;
-    exit 0
+let check_lint ?test_config output =
+  let f = function
+    | Ok () ->
+      Printf.printf "Ok ()\n";
+      exit 0
+    | Error (`Msg s) ->
+      Printf.printf "Error \"%s\"\n" s;
+      exit 0
+    | Error (`Active _) as s -> s
   in
-  Option.iter (fun _ -> ignore @@ f ()) test_config
+  match test_config with
+  | None -> output
+  | Some Lint -> f output

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -217,17 +217,20 @@ module Check = struct
         Lwt.return errors
 
   (** [package_name_collision p0 p1] returns true if [p0] is similar to [p1].
-    Similarity is defined to be either case-insensitive string equality
-    considering '_' and '-' to be equal, or a Levenshtein distance within
-    1/6 of the length of the string (rounding up).
+    Similarity is defined to be either:
+
+    - Case-insensitive string equality considering underscores ([_])
+      and dashes ([-]) to be equal
+    - A Levenshtein distance within 1/6 of the length of the string (rounding up),
+      with names of three characters or less ignored as a special case
     
     As examples, by this relation:
 
-    - "lru-cache" and "lru_cache" collide
-    - "lru-cache" and "LRU-cache" collide
-    - "lru-cache" and "cache-lru" do not collide 
-    - "ocaml" and "dcaml" collide
-    - "ocamlfind" and "ocamlbind" do not collide *)
+    - [lru-cache] and [lru_cache] collide
+    - [lru-cache] and [LRU-cache] collide
+    - [lru-cache] and [cache-lru] do not collide
+    - [ocaml] and [pcaml] collide
+    - [ocamlfind] and [ocamlbind] do not collide *)
   let package_name_collision p0 p1 =
     let dash_underscore p0 p1 =
       let f = function
@@ -243,7 +246,7 @@ module Check = struct
       if l <= 3 then false
       else
         let k = ((l - 1) / 6) + 1 in
-        Option.is_none @@ Mula.Strings.Lev.get_distance ~k p0 p1
+        Option.is_some @@ Mula.Strings.Lev.get_distance ~k p0 p1
     in
     dash_underscore p0 p1 || levenstein_distance p0 p1
 

--- a/opam-repo-ci-service.opam
+++ b/opam-repo-ci-service.opam
@@ -40,6 +40,7 @@ depends: [
   "dockerfile" {>= "6.3.0"}
   "dockerfile-opam" {>= "6.3.0"}
   "ocaml-version" {>= "2.4.0"}
+  "mula" {>= "0.1.2"}
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
   "odoc" {with-doc}

--- a/test/lint-correct.t
+++ b/test/lint-correct.t
@@ -1,4 +1,5 @@
   $ sh "scripts/setup_repo.sh"
+  $ git checkout -qb new-branch
   $ git apply "patches/b-correct.patch"
   $ git add .
   $ git commit -qm b-correct

--- a/test/lint-incorrect-opam.t
+++ b/test/lint-incorrect-opam.t
@@ -10,5 +10,5 @@ Tests the following:
   $ git commit -qm b-incorrect-opam
   $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --no-web-server
   Error "2 errors:
-  Error in b.0.0.2:              error  3: File format error in 'unknown-field' at line 11, column 0: Invalid field unknown-field
-  Error in b.0.0.1:            warning 25: Missing field 'authors'"
+  Error in b.0.0.1:            warning 25: Missing field 'authors'
+  Error in b.0.0.2:              error  3: File format error in 'unknown-field' at line 11, column 0: Invalid field unknown-field"

--- a/test/lint-incorrect-opam.t
+++ b/test/lint-incorrect-opam.t
@@ -4,6 +4,7 @@ Tests the following:
 - [b.0.0.3] is correct
 
   $ sh "scripts/setup_repo.sh"
+  $ git checkout -qb new-branch
   $ git apply "patches/b-incorrect-opam.patch"
   $ git add .
   $ git commit -qm b-incorrect-opam

--- a/test/lint-name-collision.t
+++ b/test/lint-name-collision.t
@@ -2,12 +2,36 @@ Tests the package name collision detection by adding four versions
 of a package [a_1] that conflicts with the existing [a-1] package
 
   $ sh "scripts/setup_repo.sh"
+  $ git checkout -qb new-branch-1
   $ git apply "patches/a_1-name-collision.patch"
   $ git add .
   $ git commit -qm a_1-name-collision
-  $ opam-repo-ci-local --repo="." --branch=new-branch --lint-only --no-web-server
+  $ opam-repo-ci-local --repo="." --branch=new-branch-1 --lint-only --no-web-server
   Error "4 errors:
   Warning in a_1.0.1.1: Possible name collision with package 'a-1'
   Warning in a_1.0.1.0: Possible name collision with package 'a-1'
   Warning in a_1.0.0.2: Possible name collision with package 'a-1'
   Warning in a_1.0.0.1: Possible name collision with package 'a-1'"
+
+Delete OCurrent cache
+
+  $ rm -rf var/
+
+Adds initial packages [field] and [fieldfind] to master, and new
+packages [fielf], [fielffind], and [fielffinder] to the new branch
+to test various positive and negative cases
+
+  $ git checkout -q master
+  $ git apply "patches/levenshtein-1.patch"
+  $ git add .
+  $ git commit -qm levenshtein-1
+  $ git checkout -qb new-branch-2
+  $ git apply "patches/levenshtein-2.patch"
+  $ git add .
+  $ git commit -qm levenshtein-2
+  $ opam-repo-ci-local --repo="." --branch=new-branch-2 --lint-only --no-web-server
+  Error "4 errors:
+  Warning in fielf.0.0.1: Possible name collision with package 'field'
+  Warning in fieffinder.0.0.1: Possible name collision with package 'fieffind'
+  Warning in fieffind.0.0.1: Possible name collision with package 'fieffinder'
+  Warning in fieffind.0.0.1: Possible name collision with package 'fieldfind'"

--- a/test/lint-name-collision.t
+++ b/test/lint-name-collision.t
@@ -8,10 +8,10 @@ of a package [a_1] that conflicts with the existing [a-1] package
   $ git commit -qm a_1-name-collision
   $ opam-repo-ci-local --repo="." --branch=new-branch-1 --lint-only --no-web-server
   Error "4 errors:
-  Warning in a_1.0.1.1: Possible name collision with package 'a-1'
-  Warning in a_1.0.1.0: Possible name collision with package 'a-1'
+  Warning in a_1.0.0.1: Possible name collision with package 'a-1'
   Warning in a_1.0.0.2: Possible name collision with package 'a-1'
-  Warning in a_1.0.0.1: Possible name collision with package 'a-1'"
+  Warning in a_1.0.1.0: Possible name collision with package 'a-1'
+  Warning in a_1.0.1.1: Possible name collision with package 'a-1'"
 
 Delete OCurrent cache
 
@@ -31,7 +31,7 @@ to test various positive and negative cases
   $ git commit -qm levenshtein-2
   $ opam-repo-ci-local --repo="." --branch=new-branch-2 --lint-only --no-web-server
   Error "4 errors:
-  Warning in fielf.0.0.1: Possible name collision with package 'field'
-  Warning in fieffinder.0.0.1: Possible name collision with package 'fieffind'
   Warning in fieffind.0.0.1: Possible name collision with package 'fieffinder'
-  Warning in fieffind.0.0.1: Possible name collision with package 'fieldfind'"
+  Warning in fieffind.0.0.1: Possible name collision with package 'fieldfind'
+  Warning in fieffinder.0.0.1: Possible name collision with package 'fieffind'
+  Warning in fielf.0.0.1: Possible name collision with package 'field'"

--- a/test/patches/levenshtein-1.patch
+++ b/test/patches/levenshtein-1.patch
@@ -1,0 +1,36 @@
+diff --git a/packages/field/field.0.0.1/opam b/packages/field/field.0.0.1/opam
+new file mode 100644
+index 0000000..5246a83
+--- /dev/null
++++ b/packages/field/field.0.0.1/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []
+diff --git a/packages/fieldfind/fieldfind.0.0.1/opam b/packages/fieldfind/fieldfind.0.0.1/opam
+new file mode 100644
+index 0000000..5246a83
+--- /dev/null
++++ b/packages/fieldfind/fieldfind.0.0.1/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []

--- a/test/patches/levenshtein-2.patch
+++ b/test/patches/levenshtein-2.patch
@@ -1,0 +1,54 @@
+diff --git a/packages/fieffind/fieffind.0.0.1/opam b/packages/fieffind/fieffind.0.0.1/opam
+new file mode 100644
+index 0000000..5246a83
+--- /dev/null
++++ b/packages/fieffind/fieffind.0.0.1/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []
+diff --git a/packages/fieffinder/fieffinder.0.0.1/opam b/packages/fieffinder/fieffinder.0.0.1/opam
+new file mode 100644
+index 0000000..5246a83
+--- /dev/null
++++ b/packages/fieffinder/fieffinder.0.0.1/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []
+diff --git a/packages/fielf/fielf.0.0.1/opam b/packages/fielf/fielf.0.0.1/opam
+new file mode 100644
+index 0000000..5246a83
+--- /dev/null
++++ b/packages/fielf/fielf.0.0.1/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []

--- a/test/scripts/setup_repo.sh
+++ b/test/scripts/setup_repo.sh
@@ -8,4 +8,3 @@ git checkout -qb master
 git apply "patches/a-1.patch"
 git add .
 git commit -qm a-1
-git checkout -qb new-branch


### PR DESCRIPTION
Augments the lint check by testing whether the new package's name is within a certain edit distance of any other, principally to avoid typosquatting.

The cutoff is chosen as follows, but can be easily changed:

- For names of three characters or less, we don't check the distance
- Up to six characters, we check for an edit distance of one
- Up to twelve characters, edit distance of two
- Etc.

Closes https://github.com/ocurrent/opam-repo-ci/issues/264.