### PR TITLE
Increase timeout for RISCV64 builds

### DIFF
--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -100,6 +100,9 @@ module Op = struct
       { Key.pool; commit; variant; ty } =
     let { connection; timeout } = config in
     let master = Current_git.Commit.hash master in
+    let timeout = match Variant.arch variant with
+      | `Riscv64 -> Int64.mul timeout 2L
+      | _ -> timeout in
     let os = match Variant.os variant with
       | `Macos | `Linux | `Freebsd -> `Unix
     in


### PR DESCRIPTION
Proposed PR to address https://github.com/ocaml/infrastructure/issues/107.

This matches the timeout allowance we make in Ocurrent-deployer.  https://github.com/ocurrent/ocurrent-deployer/blob/9bc4cb9be497145ae3763d93d0e081287fa4e2f7/src/pipeline.ml#L428