### PR TITLE
Add detail to jobs-per-pr metric

### DIFF
--- a/lib/index.ml
+++ b/lib/index.ml
@@ -115,10 +115,10 @@ module Commit_info_cache = struct
 
   type elt = {
     build_status : build_status;
-    n_jobs : int
+    summary : Summary.t
   }
 
-  let empty_elt = { build_status = `Not_started; n_jobs = 0 }
+  let empty_elt = { build_status = `Not_started; summary = Summary.empty }
 
   let cache : (key, elt) Hashtbl.t = Hashtbl.create 1_000
   let cache_max_size = 1_000_000
@@ -144,7 +144,7 @@ module Commit_info_cache = struct
 
   let find_build_status ~owner ~name ~hash = (find ~owner ~name ~hash).build_status
 
-  let find_n_jobs ~owner ~name ~hash = (find ~owner ~name ~hash).n_jobs
+  let find_summary ~owner ~name ~hash = (find ~owner ~name ~hash).summary
 
   let remove ~owner ~name ~hash =
     let key = (owner, name, hash) in
@@ -160,7 +160,7 @@ module Commit_info_cache = struct
           List.find_opt (fun (_, hash') -> String.equal hash hash') refs
           |> function
           | None -> acc
-          | Some (ref, _) -> (ref, status.n_jobs) :: acc
+          | Some (ref, _) -> (ref, status.summary) :: acc
         else acc)
       cache
       []
@@ -168,10 +168,10 @@ end
 
 let get_build_status = Commit_info_cache.find_build_status
 
-let get_n_jobs = Commit_info_cache.find_n_jobs
+let get_summary = Commit_info_cache.find_summary
 
-let set_status ~owner ~name ~hash (build_status, n_jobs) =
-  Commit_info_cache.add ~owner ~name ~hash Commit_info_cache.{build_status; n_jobs}
+let set_status ~owner ~name ~hash (build_status, summary) =
+  Commit_info_cache.add ~owner ~name ~hash Commit_info_cache.{build_status; summary}
 
 let get_n_per_status () = !Metrics.n_per_status
 

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -42,18 +42,18 @@ val get_build_status:
   build_status
 (** [get_build_status ~owner ~name ~hash] is the latest status for this combination. *)
 
-val get_n_jobs:
+val get_summary:
   owner:string ->
   name:string ->
   hash:string ->
-  int
-(** [get_n_jobs ~owner ~name ~hash] is the latest number of jobs for this combination. *)
+  Summary.t
+(** [get_summary ~owner ~name ~hash] is the latest number of jobs for this combination per state. *)
 
 val set_status:
   owner:string ->
   name:string ->
   hash:string ->
-  build_status * int ->
+  build_status * Summary.t ->
   unit
 (** [set_status ~owner ~name ~hash build_status] sets the latest status and number of jobs for this combination. *)
 
@@ -85,5 +85,5 @@ val get_active_refs : Current_github.Repo_id.t -> (string * string) list
 (** [get_active_refs repo] is the entries last set for [repo] with [set_active_refs], or
     [] if this repository isn't known. *)
 
-val get_jobs_per_ref : Current_github.Repo_id.t -> (string * int) list
+val get_jobs_per_ref : Current_github.Repo_id.t -> (string * Summary.t) list
 (** [get_jobs_per_ref repo] is the number of jobs run for each ref in [repo]. *)

--- a/lib/summary.ml
+++ b/lib/summary.ml
@@ -1,0 +1,44 @@
+open Current.Syntax
+
+type t = { ok: int; pending: int; err: int; skip: int; lint: int }
+
+let merge a b =
+  {
+    ok = a.ok + b.ok;
+    pending = a.pending + b.pending;
+    err = a.err + b.err;
+    skip = a.skip + b.skip;
+    lint = a.lint + b.lint;
+  }
+
+let empty = { ok = 0; pending = 0; err = 0; skip = 0; lint = 0 }
+let ok = { empty with ok = 1 }
+let pending = { empty with pending = 1 }
+let err = { empty with err = 1 }
+let skip = { empty with skip = 1 }
+let lint = { empty with lint = 1 }
+
+let of_current t =
+  let+ result = Current.state ~hidden:true t in
+  match result with
+  | Ok `Analysed -> empty
+  | Ok `Linted -> lint
+  | Ok `Built -> ok
+  | Error `Msg m when Astring.String.is_prefix ~affix:"[SKIP]" m -> skip
+  | Error `Msg _ -> err
+  | Error `Active _ -> pending
+
+let to_string { ok; pending; err; skip; lint } =
+  let lint = lint > 0 in
+  let main_jobs =
+    if pending > 0 then Error (`Active `Running)
+    else match ok, err, skip with
+      | 0, 0, 0 -> Ok "No build was necessary"
+      | 0, 0, _skip -> Error (`Msg "Everything was skipped")
+      | ok, 0, 0 -> Ok (Fmt.str "%d jobs passed" ok)
+      | ok, 0, skip -> Ok (Fmt.str "%d jobs passed, %d jobs skipped" ok skip)
+      | ok, err, skip -> Error (`Msg (Fmt.str "%d jobs failed, %d jobs skipped, %d jobs passed" err skip ok))
+  in
+  (lint, main_jobs)
+
+let sum { ok; pending; err; skip; lint } = ok + pending + err + skip + lint

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -1,4 +1,5 @@
 module Index = Opam_repo_ci.Index
+module Summary = Opam_repo_ci.Summary
 
 let jobs =
   let state f (variant, state) = Fmt.pf f "%s:%a" variant Index.pp_job_state state in
@@ -14,17 +15,17 @@ let test_simple () =
   Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
                                      VALUES ('test', x'00', 'job1', x'01', 1, x'02', '2019-11-01 9:00', '2019-11-01 9:01', '2019-11-01 9:02', 0)";
   Index.set_active_refs ~repo ["master", hash];
-  Index.set_status ~owner ~name ~hash (`Pending, 0);
+  Index.set_status ~owner ~name ~hash (`Pending, Summary.empty);
   Index.record ~repo ~hash @@ Index.Job_map.of_list [ "analysis", Some "job1"; "alpine", None ];
   Alcotest.(check (list string)) "Repos" ["name"] @@ Index.list_repos owner;
   Alcotest.(check (list (pair string string))) "Refs" ["master", hash] @@ Index.get_active_refs repo;
   Alcotest.(check jobs) "Jobs" ["alpine", `Not_started; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
   Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
                                      VALUES ('test', x'01', 'job2', x'01', 0, x'21', '2019-11-01 9:03', '2019-11-01 9:04', '2019-11-01 9:05', 0)";
-  Index.set_status ~owner ~name ~hash (`Failed, 0);
+  Index.set_status ~owner ~name ~hash (`Failed, Summary.empty);
   Index.record ~repo ~hash @@ Index.Job_map.of_list [ "analysis", Some "job1"; "alpine", Some "job2" ];
   Alcotest.(check jobs) "Jobs" ["alpine", `Failed "!"; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
-  Index.set_status ~owner ~name ~hash (`Passed, 0);
+  Index.set_status ~owner ~name ~hash (`Passed, Summary.empty);
   Index.record ~repo ~hash @@ Index.Job_map.of_list [ "analysis", Some "job1" ];
   Alcotest.(check jobs) "Jobs" ["analysis", `Passed] @@ Index.get_jobs ~owner ~name hash
 


### PR DESCRIPTION
Splits the number of jobs per status, to give more info about what failed, succeeded, and is actually putting load on the cluster.

<img width="708" alt="Screenshot 2024-03-27 at 11 14 10" src="https://github.com/ocurrent/opam-repo-ci/assets/13054139/25777374-b258-4e1c-bd34-9f40a3023763">
