### PR TITLE
Separate revdeps in web UI

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -46,16 +46,21 @@ let get_significant_available_pkg = function
 
 (** The stable releases of OCaml since 4.02 plus the latest
     alpha / beta / release-candidate for each unreleased version. *)
-let compilers ~arch ~build =
+let compilers ?(minimal=false) ~arch ~build () =
   let master_distro = Distro.tag_of_distro master_distro in
-  (Ocaml_version.Releases.recent @ Ocaml_version.Releases.unreleased_betas) |>
+  let versions =
+    if minimal then
+      [ List.hd @@ List.rev Ocaml_version.Releases.recent ]
+    else
+      Ocaml_version.Releases.recent @ Ocaml_version.Releases.unreleased_betas
+  in
   List.map (fun v ->
     let v = Ocaml_version.with_just_major_and_minor v in
     let revdeps = List.exists (Ocaml_version.equal v) default_compilers in (* TODO: Remove this when the cluster is ready *)
     let v = Ocaml_version.to_string v in
     let variant = Variant.v ~arch ~distro:master_distro ~compiler:(v, None) in
     build ~opam_version ~lower_bounds:true ~revdeps v variant
-  )
+  ) versions
 
 let linux_distributions ~arch ~build =
   let build ~distro ~arch ~compiler =
@@ -246,7 +251,7 @@ let with_cluster ~ocluster ~analysis ~lint ~master source =
   let build = build (module Builder) ~analysis ~pkgs ~master ~source in
   [
     Node.leaf ~label:"(lint)" (Node.action `Linted lint);
-    Node.branch ~label:"compilers" (compilers ~arch:`X86_64 ~build);
+    Node.branch ~label:"compilers" (compilers ~arch:`X86_64 ~build ());
     Node.branch ~label:"distributions" (linux_distributions ~arch:`X86_64 ~build);
     Node.branch ~label:"macos" (macos ~build);
     Node.branch ~label:"freebsd" (freebsd ~build);
@@ -262,6 +267,5 @@ let with_docker ~host_arch ~analysis ~lint ~master source =
   let build = build (module Builder) ~analysis ~pkgs ~master ~source in
   [
     Node.leaf ~label:"(lint)" (Node.action `Linted lint);
-    Node.branch ~label:"compilers" (compilers ~arch:host_arch ~build);
-    Node.branch ~label:"distributions" (linux_distributions ~arch:host_arch ~build);
+    Node.branch ~label:"compilers" (compilers ~minimal:true ~arch:host_arch ~build ());
   ]

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -1,4 +1,5 @@
 val compilers :
+  ?minimal:bool ->
   arch:Ocaml_version.arch ->
   build:
     (opam_version:[> `Dev ] ->
@@ -7,6 +8,7 @@ val compilers :
     string ->
     Variant.t ->
     'a) ->
+  unit ->
   'a list
 
 val linux_distributions :

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -107,9 +107,9 @@ module Op = struct
       let base = Spec.base_to_string base in
       match ty with
       | `Opam (`List_revdeps { opam_version }, pkg) ->
-          Opam_build.revdeps ~for_docker ~opam_version ~base ~variant ~pkg
+          Opam_build.revdeps ~for_docker ~opam_version ~base ~variant ~pkg ()
       | `Opam (`Build { revdep; lower_bounds; with_tests; opam_version }, pkg) ->
-          Opam_build.spec ~for_docker ~opam_version ~base ~variant ~revdep ~lower_bounds ~with_tests ~pkg
+          Opam_build.spec ~for_docker ~opam_version ~base ~variant ~revdep ~lower_bounds ~with_tests ~pkg ()
     in
     Current.Job.write job
       (Fmt.str "@.\

--- a/lib/local_build.ml
+++ b/lib/local_build.ml
@@ -148,9 +148,9 @@ module Op = struct
       let base = Spec.base_to_string base in
       match ty with
       | `Opam (`List_revdeps { opam_version }, pkg) ->
-          Opam_build.revdeps ~for_docker:true ~opam_version ~base ~variant ~pkg
+          Opam_build.revdeps ~local:true ~for_docker:true ~opam_version ~base ~variant ~pkg ()
       | `Opam (`Build { revdep; lower_bounds; with_tests; opam_version }, pkg) ->
-          Opam_build.spec ~for_docker:true ~opam_version ~base ~variant ~revdep ~lower_bounds ~with_tests ~pkg
+          Opam_build.spec ~local:true ~for_docker:true ~opam_version ~base ~variant ~revdep ~lower_bounds ~with_tests ~pkg ()
     in
     let base =
       match base with

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -1,4 +1,5 @@
 val spec :
+  ?local:bool ->
   for_docker:bool ->
   opam_version:[`V2_0 | `V2_1 | `Dev] ->
   base:string ->
@@ -7,12 +8,15 @@ val spec :
   lower_bounds:bool ->
   with_tests:bool ->
   pkg:OpamPackage.t ->
+  unit ->
   Obuilder_spec.t
 
 val revdeps :
+  ?local:bool ->
   for_docker:bool ->
   opam_version:[`V2_0 | `V2_1 | `Dev] ->
   base:string ->
   variant:Variant.t ->
   pkg:OpamPackage.t ->
+  unit ->
   Obuilder_spec.t

--- a/test/test.ml
+++ b/test/test.ml
@@ -73,7 +73,7 @@ let dump () =
           ~revdep:None
           ~lower_bounds:ob.lower_bounds
           ~with_tests:ob.with_tests
-          ~pkg
+          ~pkg ()
         |> Obuilder_spec.Docker.dockerfile_of_spec ~buildkit:true ~os:`Unix
         |> indent
       in
@@ -88,7 +88,7 @@ let dump () =
           ~opam_version:lr.opam_version
           ~base
           ~variant
-          ~pkg
+          ~pkg ()
         |> Obuilder_spec.Docker.dockerfile_of_spec ~buildkit:true ~os:`Unix
         |> indent
       in

--- a/test/test.ml
+++ b/test/test.ml
@@ -28,7 +28,7 @@ let specs =
     image @ lower_bounds @ revdeps
   in
   List.concat @@
-    (Build.compilers ~arch ~build) @
+    (Build.compilers ~arch ~build ()) @
     (Build.linux_distributions ~arch ~build) @
     (Build.macos ~build) @
     (Build.freebsd ~build) @

--- a/web-ui/github.ml
+++ b/web-ui/github.ml
@@ -135,7 +135,10 @@ let link_jobs ~owner ~name ~hash ?selected jobs =
     in
     Status_tree.add k x trees
   in
-  let full_tree = Status_tree.render (List.fold_left render_job [] jobs) in
+  let status_tree = List.fold_left render_job [] jobs in
+  let revdeps_tree, main_tree =
+    Status_tree.partition (String.equal "revdeps") status_tree
+  in
   let error_tree =
     if errors = [] then []
     else [
@@ -145,8 +148,11 @@ let link_jobs ~owner ~name ~hash ?selected jobs =
   in
   error_tree @ [
     details
-      (summary [b [txt "Full results"]])
-      [full_tree]
+      (summary [b [txt "Main results"]])
+      [Status_tree.render main_tree];
+    details
+      (summary [b [txt "Reverse dependencies"]])
+      [Status_tree.render revdeps_tree];
   ]
 
 let short_hash = Astring.String.with_range ~len:6

--- a/web-ui/status_tree.ml
+++ b/web-ui/status_tree.ml
@@ -1,0 +1,62 @@
+module Client = Opam_repo_ci_api.Client
+
+type key = string
+
+type 'a tree =
+  | Leaf of key * 'a
+  | Branch of key * 'a option * 'a t
+and 'a t = 'a tree list
+
+let rec add k x ts = match k, ts with
+  | [], _ -> assert false
+  | [k], [] -> [Leaf (k, x)]
+  | [k], Leaf (k', _)::_ when String.equal k k' -> assert false
+  | [k], (Leaf _ as t)::ts -> t :: add [k] x ts
+  | [k], Branch (k', Some _, _)::_ when String.equal k k' -> assert false
+  | [k], Branch (k', None, t)::ts when String.equal k k' -> Branch (k, Some x, t) :: ts
+  | [k], (Branch _ as t)::ts -> t :: add [k] x ts
+  | k::ks, [] -> [Branch (k, None, add ks x [])]
+  | k::ks, Leaf (k', y)::ts when String.equal k k' -> Branch (k, Some y, add ks x []) :: ts
+  | k::ks, Branch (k', y, t)::ts when String.equal k k' -> Branch (k, y, add ks x t) :: ts
+  | _::_, t::ts -> t :: add k x ts
+
+let is_skip = Astring.String.is_prefix ~affix:"[SKIP]"
+
+open Tyxml.Html
+
+let status (s, elms1) elms2 =
+  let status_class_name =
+    match (s : Client.State.t) with
+    | NotStarted -> "not-started"
+    | Aborted -> "aborted"
+    | Failed m when is_skip m -> "skipped"
+    | Failed _ -> "failed"
+    | Passed -> "passed"
+    | Active -> "active"
+    | Undefined _ -> "undefined"
+  in
+  li ~a:[a_class [status_class_name]] (elms1 @ elms2)
+
+let tag_experimental b =
+  (* TODO: Remove this *)
+  if Astring.String.is_prefix ~affix:"macos-homebrew" b ||
+    Astring.String.is_prefix ~affix:"freebsd" b
+  then b ^ " (experimental)"
+  else b
+
+let rec render_status : (Client.State.t * _) tree -> _ = function
+  | Leaf (_, x) ->
+    status x []
+  | Branch (b, None, ss) ->
+    let b = tag_experimental b in
+    li ~a:[a_class ["none"]]
+      [txt b; ul ~a:[a_class ["statuses"]] (List.map render_status ss)]
+  | Branch (_, Some (((NotStarted | Aborted | Failed _ | Undefined _), _) as x), _) ->
+    (* Do not show children of a node that has failed (guarantees in
+       service/pipeline.ml means that only successful parents have
+       children with meaningful error messages) *)
+    status x []
+  | Branch (_, Some (((Passed | Active), _) as x), ss) ->
+    status x [ul ~a:[a_class ["statuses"]] (List.map render_status ss)]
+
+let render ss = ul ~a:[a_class ["statuses"]] (List.map render_status ss)

--- a/web-ui/status_tree.mli
+++ b/web-ui/status_tree.mli
@@ -7,6 +7,10 @@ and 'a t = 'a tree list
 
 val add : key list -> 'a -> 'a t -> 'a t
 
+val filter : ?inv:bool -> (key -> bool) -> 'a t -> 'a t
+
+val partition : (key -> bool) -> 'a t -> 'a t * 'a t
+
 val is_skip : string -> bool
 
 val render :

--- a/web-ui/status_tree.mli
+++ b/web-ui/status_tree.mli
@@ -1,0 +1,15 @@
+type key = string
+
+type 'a tree =
+  | Leaf of key * 'a
+  | Branch of key * 'a option * 'a t
+and 'a t = 'a tree list
+
+val add : key list -> 'a -> 'a t -> 'a t
+
+val is_skip : string -> bool
+
+val render :
+  (Opam_repo_ci_api.Client.State.t *
+  [< Html_types.li_content_fun > `Ul ] Tyxml_html.elt list) t ->
+  [> Html_types.ul ] Tyxml_html.elt


### PR DESCRIPTION
Failures in reverse dependencies may not be relevant, but are mixed in with other builds and so can be confusing to users.

This PR splits revdeps off into their own dropdown.

<img width="318" alt="Screenshot 2024-03-28 at 21 33 22" src="https://github.com/ocurrent/opam-repo-ci/assets/13054139/d204bc79-61e5-4aa9-b31d-ed8ef6fcd8b3">
