### PR TITLE
Don't check name collisions for existing packages

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -258,7 +258,7 @@ module Check = struct
     let equal_pkgs, other_pkgs = List.partition (fun s -> String.equal s pkg_name) packages in
     (* If the package already exists then don't check name collisions *)
     if List.compare_length_with equal_pkgs 1 >= 0 then
-      []
+      errors
     else
       List.fold_left
         (fun errors other_pkg ->

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -245,8 +245,13 @@ module Check = struct
       let l = String.length p0 in
       if l <= 3 then false
       else
-        let k = ((l - 1) / 16) + 1 in
-        Option.is_some @@ Mula.Strings.Lev.get_distance ~k p0 p1
+        let k = ((l - 1) / 16) + 2 in
+        (* Ignore distances of 1, too many false positives:
+           https://github.com/ocaml/opam-repository/pull/25678 *)
+        match Mula.Strings.Lev.get_distance ~k p0 p1 with
+        | None -> false
+        | Some n when n <= 1 -> false
+        | Some _ -> true
     in
     dash_underscore p0 p1 || levenstein_distance p0 p1
 

--- a/test/analyse.t
+++ b/test/analyse.t
@@ -88,10 +88,5 @@ Test adding new packages
   * a-1 (new-branch-1, master)
   $ opam-repo-ci-local --repo="." --branch=new-branch-2 --analyse-only --no-web-server
   {
-    "packages": [
-      [ "a_1.0.0.1", { "kind": [ "New" ], "has_tests": false } ],
-      [ "a_1.0.0.2", { "kind": [ "New" ], "has_tests": false } ],
-      [ "a_1.0.1.0", { "kind": [ "New" ], "has_tests": false } ],
-      [ "a_1.0.1.1", { "kind": [ "New" ], "has_tests": false } ]
-    ]
+    "packages": [ [ "a_1.0.0.1", { "kind": [ "New" ], "has_tests": false } ] ]
   }

--- a/test/lint.t
+++ b/test/lint.t
@@ -71,8 +71,7 @@ test various positive and negative cases
   * levenshtein-1 (master)
   * a-1
   $ opam-repo-ci-local --repo="." --branch=new-branch-2 --lint-only --no-web-server
-  Error "4 errors:
+  Error "3 errors:
   Warning in fieffind.0.0.1: Possible name collision with package 'fieffinder'
   Warning in fieffind.0.0.1: Possible name collision with package 'fieldfind'
-  Warning in fieffinder.0.0.1: Possible name collision with package 'fieffind'
-  Warning in fielf.0.0.1: Possible name collision with package 'field'"
+  Warning in fieffinder.0.0.1: Possible name collision with package 'fieffind'"

--- a/test/lint.t
+++ b/test/lint.t
@@ -47,11 +47,7 @@ of a package [a_1] that conflicts with the existing [a-1] package
   * a_1-name-collision (HEAD -> new-branch-1)
   * a-1 (master)
   $ opam-repo-ci-local --repo="." --branch=new-branch-1 --lint-only --no-web-server
-  Error "4 errors:
-  Warning in a_1.0.0.1: Possible name collision with package 'a-1'
-  Warning in a_1.0.0.2: Possible name collision with package 'a-1'
-  Warning in a_1.0.1.0: Possible name collision with package 'a-1'
-  Warning in a_1.0.1.1: Possible name collision with package 'a-1'"
+  Error "Warning in a_1.0.0.1: Possible name collision with package 'a-1'"
 
 Delete OCurrent cache
 

--- a/test/patches/a_1-name-collision.patch
+++ b/test/patches/a_1-name-collision.patch
@@ -5,74 +5,14 @@ Subject: [PATCH] a
 
 ---
  packages/a_1/a_1.0.0.1/opam | 12 ++++++++++++
- packages/a_1/a_1.0.0.2/opam | 12 ++++++++++++
- packages/a_1/a_1.0.1.0/opam | 12 ++++++++++++
- packages/a_1/a_1.0.1.1/opam | 12 ++++++++++++
  2 files changed, 24 insertions(+)
  create mode 100644 packages/a_1/a_1.0.0.1/opam
- create mode 100644 packages/a_1/a_1.0.0.2/opam
- create mode 100644 packages/a_1/a_1.0.1.0/opam
- create mode 100644 packages/a_1/a_1.0.1.1/opam
 
 diff --git a/packages/a_1/a_1.0.0.1/opam b/packages/a_1/a_1.0.0.1/opam
 new file mode 100644
 index 0000000..58229e8
 --- /dev/null
 +++ b/packages/a_1/a_1.0.0.1/opam
-@@ -0,0 +1,12 @@
-+opam-version: "2.0"
-+synopsis: "Synopsis"
-+description: "Description"
-+maintainer: "Maintainer"
-+author: "Author"
-+license: "Apache-2.0"
-+homepage: "https://github.com/ocurrent/opam-repo-ci"
-+bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
-+dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
-+doc: "https://ocurrent.github.io/ocurrent/"
-+build: []
-+depends: []
-diff --git a/packages/a_1/a_1.0.0.2/opam b/packages/a_1/a_1.0.0.2/opam
-new file mode 100644
-index 0000000..58229e8
---- /dev/null
-+++ b/packages/a_1/a_1.0.0.2/opam
-@@ -0,0 +1,12 @@
-+opam-version: "2.0"
-+synopsis: "Synopsis"
-+description: "Description"
-+maintainer: "Maintainer"
-+author: "Author"
-+license: "Apache-2.0"
-+homepage: "https://github.com/ocurrent/opam-repo-ci"
-+bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
-+dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
-+doc: "https://ocurrent.github.io/ocurrent/"
-+build: []
-+depends: []
-diff --git a/packages/a_1/a_1.0.1.0/opam b/packages/a_1/a_1.0.1.0/opam
-new file mode 100644
-index 0000000..58229e8
---- /dev/null
-+++ b/packages/a_1/a_1.0.1.0/opam
-@@ -0,0 +1,12 @@
-+opam-version: "2.0"
-+synopsis: "Synopsis"
-+description: "Description"
-+maintainer: "Maintainer"
-+author: "Author"
-+license: "Apache-2.0"
-+homepage: "https://github.com/ocurrent/opam-repo-ci"
-+bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
-+dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
-+doc: "https://ocurrent.github.io/ocurrent/"
-+build: []
-+depends: []
-diff --git a/packages/a_1/a_1.0.1.1/opam b/packages/a_1/a_1.0.1.1/opam
-new file mode 100644
-index 0000000..58229e8
---- /dev/null
-+++ b/packages/a_1/a_1.0.1.1/opam
 @@ -0,0 +1,12 @@
 +opam-version: "2.0"
 +synopsis: "Synopsis"


### PR DESCRIPTION
...and increase divisor from 6 to 16 to reduce false positives.

Extension of https://github.com/ocurrent/opam-repo-ci/pull/284.