### PR TITLE
Remove redundant --installable flag alongside --coinstallable-with

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -168,9 +168,9 @@ let revdeps ?(local=false) ~for_docker ~opam_version ~base ~variant ~pkg () =
     setup_repository ~local ~variant ~for_docker ~opam_version ()
     @ [
       run "echo '@@@OUTPUT' && \
-           opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --depopts && \
-           opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --recursive && \
-           opam list -s --color=never --depends-on %s --coinstallable-with %s --installable --all-versions --with-test --depopts && \
+           opam list -s --color=never --depends-on %s --coinstallable-with %s --all-versions --depopts && \
+           opam list -s --color=never --depends-on %s --coinstallable-with %s --all-versions --recursive && \
+           opam list -s --color=never --depends-on %s --coinstallable-with %s --all-versions --with-test --depopts && \
            echo '@@@OUTPUT'"
         pkg pkg
         pkg pkg

--- a/service/main.ml
+++ b/service/main.ml
@@ -38,22 +38,22 @@ let add_default_matching_log_rules () =
         report = {|[SKIP] Package not available|};
         score = 100;
       };
-      { (* Opam 2.0's install when the package or one of its dependencies isn't available on the current switch/plateform *)
+      { (* Opam 2.0's install when the package or one of its dependencies isn't available on the current switch/platform *)
         pattern = {|[\n]\[ERROR\] No solution for .+: The following dependencies couldn't be met:[\n]|};
         report = {|[SKIP] Package not available|};
         score = 100;
       };
-      { (* Opam 2.0's reinstall when the package or one of its dependencies isn't available on the current switch/plateform *)
+      { (* Opam 2.0's reinstall when the package or one of its dependencies isn't available on the current switch/platform *)
         pattern = {|[\n]\[ERROR\] No solution for .+: Your request can't be satisfied:[\n]|};
         report = {|[SKIP] Package not available|};
         score = 100;
       };
-      { (* Opam 2.1's install when the package or one of its dependencies isn't available on the current switch/plateform *)
+      { (* Opam 2.1's install when the package or one of its dependencies isn't available on the current switch/platform *)
         pattern = {|[\n]\[ERROR\] Package conflict![\n]|};
         report = {|[SKIP] Package not available|};
         score = 100;
       };
-      { (* Opam 2.1's reinstall when the package or one of its dependencies isn't available on the current switch/plateform *)
+      { (* Opam 2.1's reinstall when the package or one of its dependencies isn't available on the current switch/platform *)
         pattern = {|[\n]No solution found, exiting[\n]|};
         report = {|[SKIP] Package not available|};
         score = 100;

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -1146,7 +1146,7 @@ list-revdeps: debian-12-ocaml-4.14/amd64 opam-dev
     COPY --chown=1000:1000 . opam-repository/
     RUN opam repository set-url --strict default opam-repository/
     RUN opam update --depexts || true
-    RUN echo '@@@OUTPUT' && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --installable --all-versions --depopts && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --installable --all-versions --recursive && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --installable --all-versions --with-test --depopts && echo '@@@OUTPUT'
+    RUN echo '@@@OUTPUT' && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --depopts && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --recursive && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --with-test --depopts && echo '@@@OUTPUT'
 
 build: debian-12-ocaml-4.14/amd64 opam-dev with-tests
     FROM BASE_IMAGE_TAG
@@ -1389,7 +1389,7 @@ list-revdeps: debian-12-ocaml-5.1/amd64 opam-dev
     COPY --chown=1000:1000 . opam-repository/
     RUN opam repository set-url --strict default opam-repository/
     RUN opam update --depexts || true
-    RUN echo '@@@OUTPUT' && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --installable --all-versions --depopts && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --installable --all-versions --recursive && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --installable --all-versions --with-test --depopts && echo '@@@OUTPUT'
+    RUN echo '@@@OUTPUT' && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --depopts && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --recursive && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --with-test --depopts && echo '@@@OUTPUT'
 
 build: debian-12-ocaml-5.1/amd64 opam-dev with-tests
     FROM BASE_IMAGE_TAG


### PR DESCRIPTION
The --installable flag runs a filter using the installable_subset function, which is just a call to the coinstallable_subset function with an empty set as the coinstallable set of packages. The other argument of --coinstallable-with already runs the same filter with the specified package as the set with which need to be coinstallable.