### PR TITLE
New lint: disallow pin-depends to be present.

### DIFF
--- a/test/lint.t
+++ b/test/lint.t
@@ -28,9 +28,10 @@ Tests the following:
   * b-incorrect-opam (HEAD -> new-branch-1)
   * a-1 (master)
   $ opam-repo-ci-local --repo="." --branch=new-branch-1 --lint-only --no-web-server
-  Error "2 errors:
+  Error "3 errors:
   Error in b.0.0.1:            warning 25: Missing field 'authors'
-  Error in b.0.0.2:              error  3: File format error in 'unknown-field' at line 11, column 0: Invalid field unknown-field"
+  Error in b.0.0.2:              error  3: File format error in 'unknown-field' at line 11, column 0: Invalid field unknown-field
+  Error in b.0.0.3: pin-depends present. This is not allowed in the opam-repository."
 
 Reset commit and clear build cache
 

--- a/test/patches/b-incorrect-opam.patch
+++ b/test/patches/b-incorrect-opam.patch
@@ -57,7 +57,7 @@ new file mode 100644
 index 0000000..5ec1dc4
 --- /dev/null
 +++ b/packages/b/b.0.0.3/opam
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,15 @@
 +opam-version: "2.0"
 +synopsis: "Synopsis"
 +description: "Description"
@@ -72,5 +72,6 @@ index 0000000..5ec1dc4
 +depends: [
 +  "a-1" {< "0.0.2"}
 +]
++pin-depends: [ "foo.~dev" "git+https://github.com/bar/foo" ]
 -- 
 2.43.0


### PR DESCRIPTION
The opam-repository should not carry any pin-depends. Sometimes such opam packages are submitted since they come from development repositories where related libraries need to be pinned. It is tedious (and error-prone) to rely on humans checking for the not-occurence of pin-depends.