### PR TITLE
Extract analysis from OCurrent

### DIFF
--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -1,23 +1,34 @@
+type kind =
+  | New
+  | Deleted
+  | Unavailable
+  | SignificantlyChanged
+  | InsignificantlyChanged
+[@@deriving yojson]
+
+type data = {
+  kind : kind;
+  has_tests : bool;
+} [@@deriving yojson]
+
+(** Used in OCurrent pipeline *)
 module Analysis : sig
-  type kind =
-    | New
-    | Deleted
-    | Unavailable
-    | SignificantlyChanged
-    | InsignificantlyChanged
-  [@@deriving yojson]
-
-  type data = {
-    kind : kind;
-    has_tests : bool;
-  } [@@deriving yojson]
-
   type t [@@deriving yojson]
 
   val get_opam : cwd:Fpath.t -> string -> (string, unit) result Lwt.t
   val packages : t -> (OpamPackage.t * data) list
   val is_duniverse : t -> bool
   val equal : t -> t -> bool
+end
+
+(** Used for local tools *)
+module Local_analysis : sig
+  type t = { packages : (OpamPackage.t * data) list; }
+
+  val of_dir :
+    unit ->
+    master:Current_git.Commit.t ->
+    Fpath.t -> (t, [ `Msg of string ]) result Lwt.t
 end
 
 val examine :

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -37,11 +37,11 @@ let revdep_spec ~variant ~opam_version ~revdep pkg =
   Spec.opam ~variant ~lower_bounds:false ~with_tests:true ~revdep ~opam_version pkg
 
 let get_significant_available_pkg = function
-  | pkg, {Analyse.Analysis.kind = New; has_tests} ->
+  | pkg, {Analyse.kind = New; has_tests} ->
       Some {Package_opt.pkg; urgent = None; has_tests}
-  | pkg, {Analyse.Analysis.kind = SignificantlyChanged; has_tests} ->
+  | pkg, {Analyse.kind = SignificantlyChanged; has_tests} ->
       Some {Package_opt.pkg; urgent = Some (fun (`High | `Low) -> false); has_tests}
-  | _, {Analyse.Analysis.kind = Deleted | Unavailable | InsignificantlyChanged; _} ->
+  | _, {Analyse.kind = Deleted | Unavailable | InsignificantlyChanged; _} ->
       None
 
 (** The stable releases of OCaml since 4.02 plus the latest

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -391,9 +391,9 @@ module Check = struct
     exec ~cwd ~job [|"git"; "merge"; "-q"; "--"; master|] >>/= fun () ->
     Lwt_list.fold_left_s (fun errors (pkg, kind) ->
       match kind with
-      | Analyse.Analysis.Deleted ->
+      | Analyse.Deleted ->
           Lwt.return errors (* TODO *)
-      | Analyse.Analysis.(New | Unavailable | SignificantlyChanged | InsignificantlyChanged) ->
+      | Analyse.(New | Unavailable | SignificantlyChanged | InsignificantlyChanged) ->
           get_opam ~cwd pkg >>= fun opam ->
           let errors = check_name_field ~errors ~pkg opam in
           let errors = check_version_field ~errors ~pkg opam in
@@ -418,7 +418,7 @@ module Lint = struct
   module Key = struct
     type t = {
       src : Current_git.Commit.t;
-      packages : (OpamPackage.t * Analyse.Analysis.kind) list
+      packages : (OpamPackage.t * Analyse.kind) list
     }
 
     let digest {src; packages} =
@@ -427,7 +427,7 @@ module Lint = struct
         "packages", `List (List.map (fun (pkg, kind) ->
           `Assoc [
             "pkg", `String (OpamPackage.to_string pkg);
-            "kind", Analyse.Analysis.kind_to_yojson kind;
+            "kind", Analyse.kind_to_yojson kind;
           ]) packages);
       ])
   end
@@ -525,7 +525,7 @@ module Lint_cache = Current_cache.Generic(Lint)
 
 let get_packages_kind =
   Current.map (fun packages ->
-    List.map (fun (pkg, {Analyse.Analysis.kind; has_tests = _}) ->
+    List.map (fun (pkg, {Analyse.kind; has_tests = _}) ->
       (pkg, kind))
       packages)
 

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -6,6 +6,6 @@ val check :
   ?test_config:Integration_test.t ->
   host_os:string ->
   master:Current_git.Commit.t Current.t ->
-  packages:(OpamPackage.t * Analyse.Analysis.data) list Current.t ->
+  packages:(OpamPackage.t * Analyse.data) list Current.t ->
   Current_git.Commit.t Current.t ->
   unit Current.t


### PR DESCRIPTION
Many components of `opam-repo-ci` are tightly coupled to OCurrent, making it difficult to use outside of a pipeline. Ideally OCurrent should wrap local tools, such as the linting check.

This PR pulls out the OCurrent-specific bits from the analysis step, functorising over the implementations of logging and executing commands.

I will open another PR doing the same for the linting check, but the linter takes in data from analysis so this PR must be done first before we can get a fully non-OCurrent linting tool.