### PR TITLE
Remove hash check for extra files

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -568,7 +568,7 @@ module Lint = struct
                   but your opam file only requires dune >= %s. Please check which requirement is the right one, and fix the other."
           pkg ver dep
     | UnexpectedFile file ->
-        Fmt.str "Error in %s: Unexpected file in %s/files/%s" pkg (Check.path_from_pkg package) file
+        Fmt.str "Error in %s: Unexpected file in %s/%s" pkg (Check.path_from_pkg package) file
     | ForbiddenPerm file ->
         Fmt.str
           "Error in %s: Forbidden permission for file %s/%s. All files should have permissions 644."

--- a/opam-repo-ci-api.opam
+++ b/opam-repo-ci-api.opam
@@ -36,3 +36,5 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
+# See https://github.com/ocurrent/ocaml-ci/issues/931
+available: !(os-distribution = "debian" & os-version = "12" & arch = "x86_32")

--- a/opam-repo-ci-api.opam.template
+++ b/opam-repo-ci-api.opam.template
@@ -1,0 +1,2 @@
+# See https://github.com/ocurrent/ocaml-ci/issues/931
+available: !(os-distribution = "debian" & os-version = "12" & arch = "x86_32")

--- a/opam-repo-ci-client.opam
+++ b/opam-repo-ci-client.opam
@@ -38,3 +38,5 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
+# See https://github.com/ocurrent/ocaml-ci/issues/931
+available: !(os-distribution = "debian" & os-version = "12" & arch = "x86_32")

--- a/opam-repo-ci-client.opam.template
+++ b/opam-repo-ci-client.opam.template
@@ -1,0 +1,2 @@
+# See https://github.com/ocurrent/ocaml-ci/issues/931
+available: !(os-distribution = "debian" & os-version = "12" & arch = "x86_32")

--- a/opam-repo-ci-service.opam
+++ b/opam-repo-ci-service.opam
@@ -64,3 +64,5 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
+# See https://github.com/ocurrent/ocaml-ci/issues/931
+available: !(os-distribution = "debian" & os-version = "12" & arch = "x86_32")

--- a/opam-repo-ci-service.opam.template
+++ b/opam-repo-ci-service.opam.template
@@ -1,0 +1,2 @@
+# See https://github.com/ocurrent/ocaml-ci/issues/931
+available: !(os-distribution = "debian" & os-version = "12" & arch = "x86_32")

--- a/opam-repo-ci-web.opam
+++ b/opam-repo-ci-web.opam
@@ -55,3 +55,5 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
+# See https://github.com/ocurrent/ocaml-ci/issues/931
+available: !(os-distribution = "debian" & os-version = "12" & arch = "x86_32")

--- a/opam-repo-ci-web.opam.template
+++ b/opam-repo-ci-web.opam.template
@@ -1,0 +1,2 @@
+# See https://github.com/ocurrent/ocaml-ci/issues/931
+available: !(os-distribution = "debian" & os-version = "12" & arch = "x86_32")


### PR DESCRIPTION
d6df6dbfd553750b9c1d90ab06442a6ae93fee8b in #313 added a check to prevent use of extra-files in the opam-repository. Also, the repository doesn't contain any existing packages with extra-files. This means, we can get rid of the hash check for extra files in the linter.