### PR TITLE
Improve test to verify is_newly_published works

### DIFF
--- a/test/lint.t
+++ b/test/lint.t
@@ -59,7 +59,7 @@ Delete OCurrent cache
   $ rm -rf var/
 
 Tests the package name collisions detection by adding initial
-packages [field] and [fieldfind] to master, and new packages
+packages [field], [field1] and [fieldfind] to master, and new packages
 [fielf], [fielffind], and [fielffinder] to the new branch to
 test various positive and negative cases
 
@@ -76,7 +76,8 @@ test various positive and negative cases
   * levenshtein-1 (master)
   * a-1
   $ opam-repo-ci-local --repo="." --branch=new-branch-2 --lint-only --no-web-server
-  Error "3 errors:
+  Error "4 errors:
   Warning in fieffind.0.0.1: Possible name collision with package 'fieffinder'
   Warning in fieffind.0.0.1: Possible name collision with package 'fieldfind'
-  Warning in fieffinder.0.0.1: Possible name collision with package 'fieffind'"
+  Warning in fieffinder.0.0.1: Possible name collision with package 'fieffind'
+  Warning in fielf.0.0.1: Possible name collision with package 'field1'"

--- a/test/patches/levenshtein-1.patch
+++ b/test/patches/levenshtein-1.patch
@@ -16,6 +16,24 @@ index 0000000..5246a83
 +doc: "https://ocurrent.github.io/ocurrent/"
 +build: []
 +depends: []
+diff --git a/packages/field1/field1.0.0.1/opam b/packages/field1/field1.0.0.1/opam
+new file mode 100644
+index 0000000..5246a83
+--- /dev/null
++++ b/packages/field1/field1.0.0.1/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []
 diff --git a/packages/fieldfind/fieldfind.0.0.1/opam b/packages/fieldfind/fieldfind.0.0.1/opam
 new file mode 100644
 index 0000000..5246a83

--- a/test/patches/levenshtein-2.patch
+++ b/test/patches/levenshtein-2.patch
@@ -34,6 +34,24 @@ index 0000000..5246a83
 +doc: "https://ocurrent.github.io/ocurrent/"
 +build: []
 +depends: []
+diff --git a/packages/field1/field1.0.0.2/opam b/packages/field1/field1.0.0.2/opam
+new file mode 100644
+index 0000000..5246a83
+--- /dev/null
++++ b/packages/field1/field1.0.0.2/opam
+@@ -0,0 +1,12 @@
++opam-version: "2.0"
++synopsis: "Synopsis"
++description: "Description"
++maintainer: "Maintainer"
++author: "Author"
++license: "Apache-2.0"
++homepage: "https://github.com/ocurrent/opam-repo-ci"
++bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
++dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
++doc: "https://ocurrent.github.io/ocurrent/"
++build: []
++depends: []
 diff --git a/packages/fielf/fielf.0.0.1/opam b/packages/fielf/fielf.0.0.1/opam
 new file mode 100644
 index 0000000..5246a83


### PR DESCRIPTION
4d94c9f5437050e8007d9f6604d53c5b7593ca62 fixed an extra space in the shell command being run to detect new packages, which caused the exec to crash and caused the lint to fail. Our cram tests should have caught this, but didn't. This is because the spawned git command is expected to fail when run for a newly published package and the name conflict test only tests with newly published packages, and no already published ones.

This commit adds an "initial" package (field1) to the name collision test, which shouldn't trigger a check for name collisions. This test improvement would help catch any future regressions, even when extract the linting code to a separate tool or library.

NOTE: It is weird that the package `fielf` conflicts with `field1`, but not with `field`. This weirdness can be confusing to end-users, but is out of the scope of this commit.