### PR TITLE
Add opam 2.2 to test matrix

### DIFF
--- a/doc/doc.ml
+++ b/doc/doc.ml
@@ -4,13 +4,14 @@ module Git = Current_git
 
 type platform = {
   variant : Variant.t;
-  opam_version : [ `Dev | `V2_0 | `V2_1];
+  opam_version : [ `Dev | `V2_0 | `V2_1 | `V2_2];
   lower_bounds : bool;
   revdeps : bool;
 }
 
 let opam_version_to_string = function
   | `Dev -> "dev"
+  | `V2_2 -> "2.2"
   | `V2_1 -> "2.1"
   | `V2_0 -> "2.0"
 

--- a/doc/doc.ml
+++ b/doc/doc.ml
@@ -4,16 +4,10 @@ module Git = Current_git
 
 type platform = {
   variant : Variant.t;
-  opam_version : [ `Dev | `V2_0 | `V2_1 | `V2_2];
+  opam_version : Opam_version.t;
   lower_bounds : bool;
   revdeps : bool;
 }
-
-let opam_version_to_string = function
-  | `Dev -> "dev"
-  | `V2_2 -> "2.2"
-  | `V2_1 -> "2.1"
-  | `V2_0 -> "2.0"
 
 let yesno_of_bool b = if b then "Yes" else "No"
 
@@ -23,7 +17,7 @@ let output_platform { variant; opam_version; lower_bounds; revdeps } =
     (Variant.distribution variant)
     (Ocaml_version.string_of_arch @@ Variant.arch variant)
     (Variant.ocaml_version_to_string variant)
-    (opam_version_to_string opam_version)
+    (Opam_version.to_string opam_version)
     (yesno_of_bool lower_bounds)
     (yesno_of_bool revdeps)
 

--- a/doc/dune
+++ b/doc/dune
@@ -3,8 +3,9 @@
  (libraries opam_repo_ci))
 
 (rule
-  (target platforms-new.md)
-  (action (run ./doc.exe -o %{target})))
+ (target platforms-new.md)
+ (action
+  (run ./doc.exe -o %{target})))
 
 (rule
  (alias doc)

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -153,9 +153,10 @@ let extras ~build =
             Some (build ~opam_version ~arch ~distro:master_distro ~compiler:(comp, None) label)
       ) Ocaml_version.arches
     in
-    build ~opam_version:`V2_0 ~arch:`X86_64 ~distro:master_distro ~compiler:(comp, None) "opam-2.0" ::
-    build ~opam_version:`V2_1 ~arch:`X86_64 ~distro:master_distro ~compiler:(comp, None) "opam-2.1" ::
-    build ~opam_version:`V2_2 ~arch:`X86_64 ~distro:master_distro ~compiler:(comp, None) "opam-2.2" ::
+    List.map (fun opam_version ->
+      let opam_string = "opam-" ^ Opam_version.to_string opam_version in
+      build ~opam_version ~arch:`X86_64 ~distro:master_distro ~compiler:(comp, None) opam_string)
+      [ `V2_0; `V2_1; `V2_2 ] @
     switches @ arches @ acc
   ) [] default_compilers_full
 

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -155,6 +155,7 @@ let extras ~build =
     in
     build ~opam_version:`V2_0 ~arch:`X86_64 ~distro:master_distro ~compiler:(comp, None) "opam-2.0" ::
     build ~opam_version:`V2_1 ~arch:`X86_64 ~distro:master_distro ~compiler:(comp, None) "opam-2.1" ::
+    build ~opam_version:`V2_2 ~arch:`X86_64 ~distro:master_distro ~compiler:(comp, None) "opam-2.2" ::
     switches @ arches @ acc
   ) [] default_compilers_full
 

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -44,7 +44,7 @@ val freebsd :
 
 val extras :
   build:
-    (opam_version:[> `Dev | `V2_0 | `V2_1 ] ->
+    (opam_version:[> `Dev | `V2_0 | `V2_1 | `V2_2 ] ->
     lower_bounds:bool ->
     revdeps:bool ->
     string ->

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -44,7 +44,7 @@ val freebsd :
 
 val extras :
   build:
-    (opam_version:[> `Dev | `V2_0 | `V2_1 | `V2_2 ] ->
+    (opam_version:Opam_version.t ->
     lower_bounds:bool ->
     revdeps:bool ->
     string ->

--- a/lib/build_intf.ml
+++ b/lib/build_intf.ml
@@ -21,7 +21,7 @@ module type S = sig
       after the job specified by [after], making it a dependency. *)
   val list_revdeps :
     variant:Variant.t ->
-    opam_version:[`V2_0 | `V2_1 | `V2_2 | `Dev] ->
+    opam_version:Opam_version.t ->
     pkgopt:Package_opt.t Current.t ->
     new_pkgs:OpamPackage.t list Current.t ->
     base:Spec.base Current.t ->

--- a/lib/build_intf.ml
+++ b/lib/build_intf.ml
@@ -21,7 +21,7 @@ module type S = sig
       after the job specified by [after], making it a dependency. *)
   val list_revdeps :
     variant:Variant.t ->
-    opam_version:[`V2_0 | `V2_1 | `Dev] ->
+    opam_version:[`V2_0 | `V2_1 | `V2_2 | `Dev] ->
     pkgopt:Package_opt.t Current.t ->
     new_pkgs:OpamPackage.t list Current.t ->
     base:Spec.base Current.t ->

--- a/lib/cluster_build.mli
+++ b/lib/cluster_build.mli
@@ -30,7 +30,7 @@ val v :
 val list_revdeps :
   t ->
   variant:Variant.t ->
-  opam_version:[`V2_0 | `V2_1 | `V2_2 | `Dev] ->
+  opam_version:Opam_version.t ->
   pkgopt:Package_opt.t Current.t ->
   new_pkgs:OpamPackage.t list Current.t ->
   base:Spec.base Current.t ->

--- a/lib/cluster_build.mli
+++ b/lib/cluster_build.mli
@@ -30,7 +30,7 @@ val v :
 val list_revdeps :
   t ->
   variant:Variant.t ->
-  opam_version:[`V2_0 | `V2_1 | `Dev] ->
+  opam_version:[`V2_0 | `V2_1 | `V2_2 | `Dev] ->
   pkgopt:Package_opt.t Current.t ->
   new_pkgs:OpamPackage.t list Current.t ->
   base:Spec.base Current.t ->

--- a/lib/local_build.mli
+++ b/lib/local_build.mli
@@ -20,7 +20,7 @@ val v :
     the job specified by [after], making it a dependency. *)
 val list_revdeps :
   variant:Variant.t ->
-  opam_version:[ `Dev | `V2_0 | `V2_1 ] ->
+  opam_version:[ `Dev | `V2_0 | `V2_1 | `V2_2 ] ->
   pkgopt:Package_opt.t Current.t ->
   new_pkgs:OpamPackage.t list Current.t ->
   base:Spec.base Current.t ->

--- a/lib/local_build.mli
+++ b/lib/local_build.mli
@@ -20,7 +20,7 @@ val v :
     the job specified by [after], making it a dependency. *)
 val list_revdeps :
   variant:Variant.t ->
-  opam_version:[ `Dev | `V2_0 | `V2_1 | `V2_2 ] ->
+  opam_version:Opam_version.t ->
   pkgopt:Package_opt.t Current.t ->
   new_pkgs:OpamPackage.t list Current.t ->
   base:Spec.base Current.t ->

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -43,14 +43,14 @@ let opam_install ~variant ~opam_version ~pin ~lower_bounds ~with_tests ~revdep ~
      (* TODO: Remove this hack when https://github.com/ocurrent/obuilder/issues/77 is fixed *)
      (* NOTE: This hack will fail for packages that have src: "git+https://..." *)
      run ~network "(%sopam reinstall --with-test %s) || true"
-       (match opam_version with `V2_1 | `Dev -> "" | `V2_0 -> fmt "opam depext%s %s && " with_tests_opt pkg_s) pkg_s
+       (match opam_version with `V2_1 | `V2_2 | `Dev -> "" | `V2_0 -> fmt "opam depext%s %s && " with_tests_opt pkg_s) pkg_s
    ] else []) @ [
     (* TODO: Replace by two calls to opam install + opam install -t using the OPAMDROPINSTALLEDPACKAGES feature *)
     (* NOTE: See above for the ~network:(if with_tests ...) hack *)
     (* NOTE: We cannot use the cache as concurrent access to the cache might overwrite it and the required archives might not be available anymore at this point *)
     let depext =
       match opam_version with
-      | `V2_1 | `Dev -> ""
+      | `V2_1 | `V2_2 | `Dev -> ""
       | `V2_0 -> fmt "opam depext%s %s && " with_tests_opt pkg_s
     in
     let verbose = if with_tests then " --verbose" else "" in
@@ -99,6 +99,7 @@ let setup_repository ?(local=false) ~variant ~for_docker ~opam_version () =
   let opam_version_str = match opam_version with
     | `V2_0 -> "2.0"
     | `V2_1 -> "2.1"
+    | `V2_2 -> "2.2"
     | `Dev -> "dev"
   in
   let opam_repo_args = match Variant.os variant with
@@ -135,7 +136,7 @@ let setup_repository ?(local=false) ~variant ~for_docker ~opam_version () =
     run "rm -rf opam-repository/";
     copy ["."] ~dst:"opam-repository/";
     run "opam repository set-url%s --strict default opam-repository/" opam_repo_args;
-    run ~network "opam %s || true" (match opam_version with `V2_1 | `Dev -> "update --depexts" | `V2_0 -> "depext -u");
+    run ~network "opam %s || true" (match opam_version with `V2_1 | `V2_2 | `Dev -> "update --depexts" | `V2_0 -> "depext -u");
   ] @
   if local then [ keep_installed ] else []
 

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -96,11 +96,7 @@ let setup_repository ?(local=false) ~variant ~for_docker ~opam_version () =
     | `Macos -> "ln"
     | `Freebsd | `Linux -> "sudo ln"
   in
-  let opam_version_str = match opam_version with
-    | `V2_0 -> "2.0"
-    | `V2_1 -> "2.1"
-    | `V2_2 -> "2.2"
-    | `Dev -> "dev"
+  let opam_version_str = Opam_version.to_string opam_version
   in
   let opam_repo_args = match Variant.os variant with
     | `Macos -> " -k local" (* TODO: (copy ...) do not copy the content of .git or something like that and make the subsequent opam pin fail *)

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -1,7 +1,7 @@
 val spec :
   ?local:bool ->
   for_docker:bool ->
-  opam_version:[`V2_0 | `V2_1 | `Dev] ->
+  opam_version:[`V2_0 | `V2_1 | `V2_2 | `Dev] ->
   base:string ->
   variant:Variant.t ->
   revdep:OpamPackage.t option ->
@@ -14,7 +14,7 @@ val spec :
 val revdeps :
   ?local:bool ->
   for_docker:bool ->
-  opam_version:[`V2_0 | `V2_1 | `Dev] ->
+  opam_version:[`V2_0 | `V2_1 | `V2_2 | `Dev] ->
   base:string ->
   variant:Variant.t ->
   pkg:OpamPackage.t ->

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -1,7 +1,7 @@
 val spec :
   ?local:bool ->
   for_docker:bool ->
-  opam_version:[`V2_0 | `V2_1 | `V2_2 | `Dev] ->
+  opam_version:Opam_version.t ->
   base:string ->
   variant:Variant.t ->
   revdep:OpamPackage.t option ->
@@ -14,7 +14,7 @@ val spec :
 val revdeps :
   ?local:bool ->
   for_docker:bool ->
-  opam_version:[`V2_0 | `V2_1 | `V2_2 | `Dev] ->
+  opam_version:Opam_version.t ->
   base:string ->
   variant:Variant.t ->
   pkg:OpamPackage.t ->

--- a/lib/opam_version.ml
+++ b/lib/opam_version.ml
@@ -1,0 +1,7 @@
+type t = [ `Dev | `V2_0 | `V2_1 | `V2_2] [@@deriving to_yojson]
+
+let to_string = function
+  | `Dev -> "dev"
+  | `V2_2 -> "2.2"
+  | `V2_1 -> "2.1"
+  | `V2_0 -> "2.0"

--- a/lib/opam_version.mli
+++ b/lib/opam_version.mli
@@ -1,0 +1,3 @@
+type t = [ `Dev | `V2_0 | `V2_1 | `V2_2] [@@deriving to_yojson]
+
+val to_string : t -> string

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -17,11 +17,11 @@ type opam_build = {
   revdep : package option;
   with_tests : bool;
   lower_bounds : bool;
-  opam_version : [`V2_0 | `V2_1 | `V2_2 | `Dev];
+  opam_version : Opam_version.t;
 } [@@deriving to_yojson]
 
 type list_revdeps = {
-  opam_version : [`V2_0 | `V2_1 | `V2_2 | `Dev];
+  opam_version : Opam_version.t;
 } [@@deriving to_yojson]
 
 type ty = [
@@ -42,21 +42,15 @@ let pp_pkg ?revdep f pkg =
   | Some revdep -> Fmt.pf f "%s with %s" (OpamPackage.to_string revdep) (OpamPackage.to_string pkg)
   | None -> Fmt.string f (OpamPackage.to_string pkg)
 
-let opam_version_to_string = function
-  | `V2_0 -> "2.0"
-  | `V2_1 -> "2.1"
-  | `V2_2 -> "2.2"
-  | `Dev -> "dev"
-
 let pp_ty f = function
   | `Opam (`List_revdeps {opam_version}, pkg) ->
       Fmt.pf f "list revdeps of %s, using opam %s" (OpamPackage.to_string pkg)
-        (opam_version_to_string opam_version)
+        (Opam_version.to_string opam_version)
   | `Opam (`Build { revdep; lower_bounds; with_tests; opam_version }, pkg) ->
     let action = if with_tests then "test" else "build" in
     Fmt.pf f "%s %a%s, using opam %s" action (pp_pkg ?revdep) pkg
       (if lower_bounds then ", lower-bounds" else "")
-      (opam_version_to_string opam_version)
+      (Opam_version.to_string opam_version)
 
 let pp_summary f = function
   | `Opam (`List_revdeps _, _) -> Fmt.string f "Opam list revdeps"

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -17,11 +17,11 @@ type opam_build = {
   revdep : package option;
   with_tests : bool;
   lower_bounds : bool;
-  opam_version : [`V2_0 | `V2_1 | `Dev];
+  opam_version : [`V2_0 | `V2_1 | `V2_2 | `Dev];
 } [@@deriving to_yojson]
 
 type list_revdeps = {
-  opam_version : [`V2_0 | `V2_1 | `Dev];
+  opam_version : [`V2_0 | `V2_1 | `V2_2 | `Dev];
 } [@@deriving to_yojson]
 
 type ty = [
@@ -45,6 +45,7 @@ let pp_pkg ?revdep f pkg =
 let opam_version_to_string = function
   | `V2_0 -> "2.0"
   | `V2_1 -> "2.1"
+  | `V2_2 -> "2.2"
   | `Dev -> "dev"
 
 let pp_ty f = function

--- a/lib/spec.mli
+++ b/lib/spec.mli
@@ -17,12 +17,12 @@ type opam_build = {
   revdep : package option;
   with_tests : bool;
   lower_bounds : bool;
-  opam_version : [ `Dev | `V2_0 | `V2_1 ];
+  opam_version : [ `Dev | `V2_0 | `V2_1 | `V2_2 ];
 }
 
 (** Configuration for a [list_revdeps] job *)
 type list_revdeps = {
-  opam_version : [ `Dev | `V2_0 | `V2_1 ];
+  opam_version : [ `Dev | `V2_0 | `V2_1 | `V2_2 ];
 }
 
 (** Configuration for any job along with the package to build *)
@@ -37,7 +37,7 @@ val opam :
   ?revdep:package ->
   variant:Variant.t ->
   lower_bounds:bool ->
-  with_tests:bool -> opam_version:[ `Dev | `V2_0 | `V2_1 ] -> package -> t
+  with_tests:bool -> opam_version:[ `Dev | `V2_0 | `V2_1 | `V2_2 ] -> package -> t
 
 val pp_ty :
   Format.formatter ->

--- a/lib/spec.mli
+++ b/lib/spec.mli
@@ -17,7 +17,7 @@ type opam_build = {
   revdep : package option;
   with_tests : bool;
   lower_bounds : bool;
-  opam_version : [ `Dev | `V2_0 | `V2_1 | `V2_2 ];
+  opam_version : Opam_version.t;
 }
 
 (** Configuration for a [list_revdeps] job *)
@@ -37,7 +37,7 @@ val opam :
   ?revdep:package ->
   variant:Variant.t ->
   lower_bounds:bool ->
-  with_tests:bool -> opam_version:[ `Dev | `V2_0 | `V2_1 | `V2_2 ] -> package -> t
+  with_tests:bool -> opam_version:Opam_version.t -> package -> t
 
 val pp_ty :
   Format.formatter ->

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -2612,6 +2612,40 @@ build: debian-12-ocaml-5.2/amd64 opam-2.1
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
+build: debian-12-ocaml-5.2/amd64 opam-2.2
+    FROM BASE_IMAGE_TAG
+    USER 1000:1000
+    WORKDIR /home/opam
+    RUN sudo ln -f /usr/bin/opam-2.2 /usr/bin/opam
+    RUN opam init --reinit -ni
+    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    ENV OPAMDOWNLOADJOBS="1"
+    ENV OPAMERRLOGLEN="0"
+    ENV OPAMSOLVERTIMEOUT="500"
+    ENV OPAMPRECISETRACKING="1"
+    ENV CI="true"
+    ENV OPAM_REPO_CI="true"
+    RUN rm -rf opam-repository/
+    COPY --chown=1000:1000 . opam-repository/
+    RUN opam repository set-url --strict default opam-repository/
+    RUN opam update --depexts || true
+    RUN opam pin add -k version -yn a.0.0.1 0.0.1
+    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
+        res=$?; \
+        test "$res" != 31 && exit "$res"; \
+        export OPAMCLI=2.0; \
+        build_dir=$(opam var prefix)/.opam-switch/build; \
+        failed=$(ls "$build_dir"); \
+        partial_fails=""; \
+        for pkg in $failed; do \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
+        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+        fi; \
+        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
+        done; \
+        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+        exit 1
+
 build: debian-12-ocaml-5.2-afl/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
@@ -2959,6 +2993,40 @@ build: debian-12-ocaml-4.14/amd64 opam-2.1
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam
+    RUN opam init --reinit -ni
+    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    ENV OPAMDOWNLOADJOBS="1"
+    ENV OPAMERRLOGLEN="0"
+    ENV OPAMSOLVERTIMEOUT="500"
+    ENV OPAMPRECISETRACKING="1"
+    ENV CI="true"
+    ENV OPAM_REPO_CI="true"
+    RUN rm -rf opam-repository/
+    COPY --chown=1000:1000 . opam-repository/
+    RUN opam repository set-url --strict default opam-repository/
+    RUN opam update --depexts || true
+    RUN opam pin add -k version -yn a.0.0.1 0.0.1
+    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
+        res=$?; \
+        test "$res" != 31 && exit "$res"; \
+        export OPAMCLI=2.0; \
+        build_dir=$(opam var prefix)/.opam-switch/build; \
+        failed=$(ls "$build_dir"); \
+        partial_fails=""; \
+        for pkg in $failed; do \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
+        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+        fi; \
+        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
+        done; \
+        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+        exit 1
+
+build: debian-12-ocaml-4.14/amd64 opam-2.2
+    FROM BASE_IMAGE_TAG
+    USER 1000:1000
+    WORKDIR /home/opam
+    RUN sudo ln -f /usr/bin/opam-2.2 /usr/bin/opam
     RUN opam init --reinit -ni
     RUN uname -rs && opam exec -- ocaml -version && opam --version
     ENV OPAMDOWNLOADJOBS="1"

--- a/test/test.ml
+++ b/test/test.ml
@@ -35,13 +35,7 @@ let specs =
     (Build.extras ~build)
 
 let header title variant ?(lower_bounds=false) ?(with_tests=false) opam_version =
-  let opam_version =
-    match opam_version with
-    | `Dev -> "opam-dev"
-    | `V2_2 -> "opam-2.2"
-    | `V2_1 -> "opam-2.1"
-    | `V2_0 -> "opam-2.0"
-  in
+  let opam_version = "opam-" ^ Opam_version.to_string opam_version in
   let lower_bounds = if lower_bounds then " lower-bounds" else "" in
   let with_tests = if with_tests then " with-tests" else "" in
   Format.asprintf "%s: %a %s%s%s"

--- a/test/test.ml
+++ b/test/test.ml
@@ -38,6 +38,7 @@ let header title variant ?(lower_bounds=false) ?(with_tests=false) opam_version 
   let opam_version =
     match opam_version with
     | `Dev -> "opam-dev"
+    | `V2_2 -> "opam-2.2"
     | `V2_1 -> "opam-2.1"
     | `V2_0 -> "opam-2.0"
   in


### PR DESCRIPTION
This PR adds opam 2.2 to the test matrix.

Until https://github.com/ocurrent/docker-base-images/pull/289 and https://github.com/ocurrent/ocaml-dockerfile/pull/215 are merged this will result in `opam 2.3.0~alpha~dev` being used. See https://github.com/ocurrent/ocaml-dockerfile/blob/5c2d8e095cb92f7e590e85b991ac93ae8209908a/src-opam/opam.ml#L208-L217 which aliases opam-2.2 to be the master branch.

Closes https://github.com/ocurrent/opam-repo-ci/issues/331.