### PR TITLE
Fix uncaught `OpamPp.Bad_format` exception

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -148,7 +148,7 @@ module Analysis = struct
     ci_extensions_equal old_file new_file &&
     depexts_equal old_file new_file
 
-  let add_changed_pgk ~path ~name ~package ~old_content pkgs =
+  let add_changed_pkg ~path ~name ~package ~old_content pkgs =
     Lwt_preemptive.detach begin function
       | Error () ->
         (* deleted package *)
@@ -195,7 +195,7 @@ module Analysis = struct
               | Ok old_content ->
                 (* NOTE: Lwt_preemptive is initialized in lint.ml to only 1 thread *)
                 get_opam ~cwd:dir path
-                >>= add_changed_pgk ~path ~name ~package ~old_content pkgs
+                >>= add_changed_pkg ~path ~name ~package ~old_content pkgs
             end
           | _ ->
             Fmt.failwith "Unexpected path %S in output (expecting 'packages/name/pkg/...')" path
@@ -250,8 +250,8 @@ module Analysis = struct
     | Ok () ->
       let open Lwt_result.Syntax in
       let* changed_pkgs = find_changed_packages ~job ~master dir in
-      let pgk_bindings = OpamPackage.Map.bindings changed_pkgs in
-      let+ packages = Lwt_list.fold_right_s (add_package_data ~dir) pgk_bindings (Ok []) in
+      let pkg_bindings = OpamPackage.Map.bindings changed_pkgs in
+      let+ packages = Lwt_list.fold_right_s (add_package_data ~dir) pkg_bindings (Ok []) in
       let r = { packages } in
       Current.Job.log job "@[<v2>Results:@,%a@]" Yojson.Safe.(pretty_print ~std:true) (to_yojson r);
       r

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -229,10 +229,9 @@ module Analysis = struct
     get_opam ~cwd:dir path >|= function
     | Error () -> assert false
     | Ok content ->
-        let filename = OpamFile.make (OpamFilename.raw path) in
-        let content = OpamFile.OPAM.read_from_string ~filename content in
-        let has_tests = has_tests content in
-        (pkg, {kind; has_tests})
+      let content = parse_opam_file_content ~path content in
+      let has_tests = has_tests content in
+      (pkg, {kind; has_tests})
 
   let of_dir ~job ~master dir =
     let master = Current_git.Commit.hash master in

--- a/test/analyse.t
+++ b/test/analyse.t
@@ -7,7 +7,7 @@ Test adding new packages
   $ git commit -qm b-correct
   $ git log --graph --pretty=format:'%s%d'
   * b-correct (HEAD -> new-branch-1)
-  * a-1 (master)
+  * a-1 (tag: initial-state, master)
   $ opam-repo-ci-local --repo="." --branch=new-branch-1 --analyse-only --no-web-server
   {
     "packages": [
@@ -19,7 +19,7 @@ Test adding new packages
 
 Reset commit and clear build cache
 
-  $ git reset -q --hard HEAD~1
+  $ git reset -q --hard initial-state
   $ rm -rf var
 
 Test packages with insignificant changes
@@ -29,7 +29,7 @@ Test packages with insignificant changes
   $ git commit -qm a-1-modified
   $ git log --graph --pretty=format:'%s%d'
   * a-1-modified (HEAD -> new-branch-1)
-  * a-1 (master)
+  * a-1 (tag: initial-state, master)
   $ opam-repo-ci-local --repo="." --branch=new-branch-1 --analyse-only --no-web-server
   {
     "packages": [
@@ -46,7 +46,7 @@ Test packages with insignificant changes
 
 Reset commit and clear build cache
 
-  $ git reset -q --hard HEAD~1
+  $ git reset -q --hard initial-state
   $ rm -rf var
 
 Test package with significant changes
@@ -62,7 +62,7 @@ Test package with significant changes
   $ git log --graph --pretty=format:'%s%d'
   * a-1-modified (HEAD -> new-branch-2)
   * b-1-correct (master)
-  * a-1 (new-branch-1)
+  * a-1 (tag: initial-state, new-branch-1)
   $ opam-repo-ci-local --repo="." --branch=new-branch-2 --analyse-only --no-web-server
   {
     "packages": [
@@ -72,9 +72,9 @@ Test package with significant changes
 
 Reset commits on [master] and [new-branch-2] and clear build cache
 
-  $ git reset -q --hard HEAD~2
+  $ git reset -q --hard initial-state
   $ git checkout -q master
-  $ git reset -q --hard HEAD~1
+  $ git reset -q --hard initial-state
   $ git checkout -q new-branch-2
   $ rm -rf var
 
@@ -85,7 +85,7 @@ Test adding new packages
   $ git commit -qm a_1-name-collision
   $ git log --graph --pretty=format:'%s%d'
   * a_1-name-collision (HEAD -> new-branch-2)
-  * a-1 (new-branch-1, master)
+  * a-1 (tag: initial-state, new-branch-1, master)
   $ opam-repo-ci-local --repo="." --branch=new-branch-2 --analyse-only --no-web-server
   {
     "packages": [ [ "a_1.0.0.1", { "kind": [ "New" ], "has_tests": false } ] ]

--- a/test/analyse.t
+++ b/test/analyse.t
@@ -90,3 +90,25 @@ Test adding new packages
   {
     "packages": [ [ "a_1.0.0.1", { "kind": [ "New" ], "has_tests": false } ] ]
   }
+
+Clean up the build cache
+
+  $ rm -rf ./var
+
+Syntactically invalid opam files are handled correctly.
+See https://github.com/ocurrent/opam-repo-ci/issues/291
+
+  $ git checkout -q -b analyze-invalid-opam-file initial-state
+  $ sed 's/depends: \[\]/depends:\[ ocaml {>= 4.15} \]/' packages/a-1/a-1.0.0.1/opam > opam.new
+  $ mv opam.new packages/a-1/a-1.0.0.1/opam
+  $ git commit -q -m "Add invalid syntax in version constraint" packages/a-1/a-1.0.0.1/opam
+  $ git diff initial-state | tail -n 3
+   build: []
+  -depends: []
+  +depends:[ ocaml {>= 4.15} ]
+  $ opam-repo-ci-local --repo="." --branch=analyze-invalid-opam-file --analyse-only --no-web-server
+  Error ""packages/a-1/a-1.0.0.1/opam" failed to be parsed: '.' is not a valid token"
+
+Clean up the build cache
+
+  $ rm -rf ./var

--- a/test/lint.t
+++ b/test/lint.t
@@ -7,7 +7,7 @@ Tests linting of correctly formatted opam packages
   $ git commit -qm b-correct
   $ git log --graph --pretty=format:'%s%d'
   * b-correct (HEAD -> new-branch-1)
-  * a-1 (master)
+  * a-1 (tag: initial-state, master)
   $ opam-repo-ci-local --repo="." --branch=new-branch-1 --lint-only --no-web-server
   Ok ()
 
@@ -27,7 +27,7 @@ Tests the following:
   $ git commit -qm b-incorrect-opam
   $ git log --graph --pretty=format:'%s%d'
   * b-incorrect-opam (HEAD -> new-branch-1)
-  * a-1 (master)
+  * a-1 (tag: initial-state, master)
   $ opam-repo-ci-local --repo="." --branch=new-branch-1 --lint-only --no-web-server
   Error "6 errors:
   Error in b.0.0.1:            warning 25: Missing field 'authors'
@@ -50,7 +50,7 @@ of a package [a_1] that conflicts with the existing [a-1] package
   $ git commit -qm a_1-name-collision
   $ git log --graph --pretty=format:'%s%d'
   * a_1-name-collision (HEAD -> new-branch-1)
-  * a-1 (master)
+  * a-1 (tag: initial-state, master)
   $ opam-repo-ci-local --repo="." --branch=new-branch-1 --lint-only --no-web-server
   Error "Warning in a_1.0.0.1: Possible name collision with package 'a-1'"
 
@@ -74,7 +74,7 @@ test various positive and negative cases
   $ git log --graph --pretty=format:'%s%d'
   * levenshtein-2 (HEAD -> new-branch-2)
   * levenshtein-1 (master)
-  * a-1
+  * a-1 (tag: initial-state)
   $ opam-repo-ci-local --repo="." --branch=new-branch-2 --lint-only --no-web-server
   Error "4 errors:
   Warning in fieffind.0.0.1: Possible name collision with package 'fieffinder'

--- a/test/scripts/setup_repo.sh
+++ b/test/scripts/setup_repo.sh
@@ -9,3 +9,4 @@ git checkout -qb master
 git apply "patches/a-1.patch"
 git add .
 git commit -qm a-1
+git tag 'initial-state'


### PR DESCRIPTION
Closes #291

Looking through the commits in sequence before reviewing is probably helpful here. Almost all the changes are simple refactoring to make the change easier, or essentially mechanical changes to convert from implicit errors via excepts to explicit error handling using `result`.

My hypothesis is that by using explicit error handling in all the cases where we try to parse opam files during analysis, we can ensure that this exception will not go unhandled. However, I'd like to test this on the running service before deploying, since we cannot reproduce this using the local version.

