### PR TITLE
Move newly published package detection to analysis

### DIFF
--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -1,5 +1,5 @@
 module Analysis : sig
-  type change = Release [@@deriving yojson]
+  type change = | Package | Release [@@deriving yojson]
   type kind =
     | New of change
     | Deleted

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -1,6 +1,7 @@
 module Analysis : sig
+  type change = Release [@@deriving yojson]
   type kind =
-    | New
+    | New of change
     | Deleted
     | Unavailable
     | SignificantlyChanged

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -37,7 +37,7 @@ let revdep_spec ~variant ~opam_version ~revdep pkg =
   Spec.opam ~variant ~lower_bounds:false ~with_tests:true ~revdep ~opam_version pkg
 
 let get_significant_available_pkg = function
-  | pkg, {Analyse.Analysis.kind = New Release; has_tests} ->
+  | pkg, {Analyse.Analysis.kind = New _; has_tests} ->
       Some {Package_opt.pkg; urgent = None; has_tests}
   | pkg, {Analyse.Analysis.kind = SignificantlyChanged; has_tests} ->
       Some {Package_opt.pkg; urgent = Some (fun (`High | `Low) -> false); has_tests}

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -37,7 +37,7 @@ let revdep_spec ~variant ~opam_version ~revdep pkg =
   Spec.opam ~variant ~lower_bounds:false ~with_tests:true ~revdep ~opam_version pkg
 
 let get_significant_available_pkg = function
-  | pkg, {Analyse.Analysis.kind = New; has_tests} ->
+  | pkg, {Analyse.Analysis.kind = New Release; has_tests} ->
       Some {Package_opt.pkg; urgent = None; has_tests}
   | pkg, {Analyse.Analysis.kind = SignificantlyChanged; has_tests} ->
       Some {Package_opt.pkg; urgent = Some (fun (`High | `Low) -> false); has_tests}

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -451,7 +451,7 @@ module Check = struct
       match kind with
       | Analyse.Analysis.Deleted ->
           Lwt.return errors (* TODO *)
-      | Analyse.Analysis.(New | Unavailable | SignificantlyChanged | InsignificantlyChanged) ->
+      | Analyse.Analysis.(New Release | Unavailable | SignificantlyChanged | InsignificantlyChanged) ->
           get_opam ~cwd pkg >>= fun opam ->
           let errors = check_name_field ~errors ~pkg opam in
           let errors = check_version_field ~errors ~pkg opam in

--- a/test/analyse.t
+++ b/test/analyse.t
@@ -11,9 +11,9 @@ Test adding new packages
   $ opam-repo-ci-local --repo="." --branch=new-branch-1 --analyse-only --no-web-server
   {
     "packages": [
-      [ "b.0.0.1", { "kind": [ "New" ], "has_tests": false } ],
-      [ "b.0.0.2", { "kind": [ "New" ], "has_tests": false } ],
-      [ "b.0.0.3", { "kind": [ "New" ], "has_tests": false } ]
+      [ "b.0.0.1", { "kind": [ "New", [ "Release" ] ], "has_tests": false } ],
+      [ "b.0.0.2", { "kind": [ "New", [ "Release" ] ], "has_tests": false } ],
+      [ "b.0.0.3", { "kind": [ "New", [ "Release" ] ], "has_tests": false } ]
     ]
   }
 
@@ -88,7 +88,9 @@ Test adding new packages
   * a-1 (tag: initial-state, new-branch-1, master)
   $ opam-repo-ci-local --repo="." --branch=new-branch-2 --analyse-only --no-web-server
   {
-    "packages": [ [ "a_1.0.0.1", { "kind": [ "New" ], "has_tests": false } ] ]
+    "packages": [
+      [ "a_1.0.0.1", { "kind": [ "New", [ "Release" ] ], "has_tests": false } ]
+    ]
   }
 
 Clean up the build cache

--- a/test/analyse.t
+++ b/test/analyse.t
@@ -11,9 +11,9 @@ Test adding new packages
   $ opam-repo-ci-local --repo="." --branch=new-branch-1 --analyse-only --no-web-server
   {
     "packages": [
-      [ "b.0.0.1", { "kind": [ "New", [ "Release" ] ], "has_tests": false } ],
-      [ "b.0.0.2", { "kind": [ "New", [ "Release" ] ], "has_tests": false } ],
-      [ "b.0.0.3", { "kind": [ "New", [ "Release" ] ], "has_tests": false } ]
+      [ "b.0.0.1", { "kind": [ "New", [ "Package" ] ], "has_tests": false } ],
+      [ "b.0.0.2", { "kind": [ "New", [ "Package" ] ], "has_tests": false } ],
+      [ "b.0.0.3", { "kind": [ "New", [ "Package" ] ], "has_tests": false } ]
     ]
   }
 
@@ -89,7 +89,7 @@ Test adding new packages
   $ opam-repo-ci-local --repo="." --branch=new-branch-2 --analyse-only --no-web-server
   {
     "packages": [
-      [ "a_1.0.0.1", { "kind": [ "New", [ "Release" ] ], "has_tests": false } ]
+      [ "a_1.0.0.1", { "kind": [ "New", [ "Package" ] ], "has_tests": false } ]
     ]
   }
 


### PR DESCRIPTION
Previously, we had code to detect newly published packages in the lint
phase to be able to run additional checks for such packages. But, this
detection belongs in the analysis phase, really.

Additionally, this PR also clarifies that the New kind really means NewRelease. 