### PR TITLE
Use 0install-solver in tests

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -23,7 +23,7 @@ let opam_install ~variant ~opam_version ~pin ~lower_bounds ~with_tests ~revdep ~
    else
      []
   ) @
-  (if revdep || lower_bounds then
+  (if revdep || lower_bounds || with_tests then
      [
        run "opam option solver=builtin-0install";
      ]

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -1181,6 +1181,7 @@ build: debian-12-ocaml-4.14/amd64 opam-dev with-tests
         done; \
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
+    RUN opam option solver=builtin-0install
     RUN (opam reinstall --with-test a.0.0.1) || true
     RUN opam reinstall --with-test --verbose a.0.0.1; \
         res=$?; \
@@ -1511,6 +1512,7 @@ build: debian-12-ocaml-5.2/amd64 opam-dev with-tests
         done; \
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
+    RUN opam option solver=builtin-0install
     RUN (opam reinstall --with-test a.0.0.1) || true
     RUN opam reinstall --with-test --verbose a.0.0.1; \
         res=$?; \


### PR DESCRIPTION
Meant to address persistent solvers timeouts causing CI tests to give false negatives.

Suggested by @kit-ty-kate