### PR TITLE
Fix Dockerfile to copy `opam-ci-check` binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /src
 RUN opam install -y --deps-only .
 ADD --chown=opam . .
 RUN opam exec -- dune build ./_build/install/default/bin/opam-repo-ci-service
+RUN cp $(opam exec -- which opam-ci-check) /src/_build/install/default/bin/opam-ci-check
 
 FROM debian:12
 RUN apt-get update && apt-get install libev4 openssh-client curl gnupg2 dumb-init git graphviz libsqlite3-dev ca-certificates netbase gzip bzip2 xz-utils unzip tar docker.io -y --no-install-recommends
@@ -15,3 +16,4 @@ WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/opam-repo-ci-service"]
 ENV OCAMLRUNPARAM=a=2
 COPY --from=build /src/_build/install/default/bin/opam-repo-ci-service /usr/local/bin/
+COPY --from=build /src/_build/install/default/bin/opam-ci-check /usr/local/bin/

--- a/opam-repo-ci-service.opam
+++ b/opam-repo-ci-service.opam
@@ -53,7 +53,7 @@ depends: [
   "opam-ci-check"
 ]
 pin-depends: [
-  "opam-ci-check.0.1~dev" "git+https://github.com/ocurrent/opam-ci-check.git#94890d5ed8d2ff6bbca0e5278af008d70468e25d"
+  "opam-ci-check.0.1~dev" "git+https://github.com/ocurrent/opam-ci-check.git#e91afc68f1a9e372e4b9cdc51fc0fb775ec0fe42"
 ]
 conflicts: [
   "ocaml-migrate-parsetree" {= "1.7.1"}


### PR DESCRIPTION
Also, upgrade to the latest version of `opam-ci-check`.

Couple of fixes to follow-up on #350 