### PR TITLE
Update opam-ci-check to address some failures

### DIFF
--- a/opam-repo-ci-service.opam
+++ b/opam-repo-ci-service.opam
@@ -53,7 +53,7 @@ depends: [
   "opam-ci-check"
 ]
 pin-depends: [
-  "opam-ci-check.0.1~dev" "git+https://github.com/ocurrent/opam-ci-check.git#e91afc68f1a9e372e4b9cdc51fc0fb775ec0fe42"
+  "opam-ci-check.0.1~dev" "git+https://github.com/ocurrent/opam-ci-check.git#b00f2e016ce6cbc311d488af1aae8d6c8854dfa0"
 ]
 conflicts: [
   "ocaml-migrate-parsetree" {= "1.7.1"}


### PR DESCRIPTION
This updates to the latest version of opam-ci-check that has fixes for a couple of failures that were noticed on builds in production.