### PR TITLE
Bump opam to 2.3.0-alpha1

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -143,8 +143,8 @@ module Analysis = struct
     let filename = OpamFile.make (OpamFilename.raw path) in
     match OpamFile.OPAM.read_from_string ~filename content with
     | opam_file -> Ok opam_file
-    | exception OpamPp.Bad_format (_, msg)
-    | exception OpamPp.Bad_version (_, msg) ->
+    | exception OpamPp.Bad_format ((_, msg) : OpamPp.bad_format)
+    | exception OpamPp.Bad_version (((_, msg): OpamPp.bad_format), _) ->
       Error (`Msg (Printf.sprintf "%S failed to be parsed: %s" path msg))
 
   let files_are_changed_significantly ~old_file ~new_file =

--- a/opam-repo-ci-service.opam
+++ b/opam-repo-ci-service.opam
@@ -36,8 +36,8 @@ depends: [
   "capnp-rpc-lwt" {>= "0.8.0"}
   "capnp-rpc-unix" {>= "0.8.0"}
   "opam-repo-ci-api"
-  "opam-state" {>= "2.2.0~beta1"}
-  "opam-format" {>= "2.2.0~beta1"}
+  "opam-state" {>= "2.3.0~alpha1"}
+  "opam-format" {>= "2.3.0~alpha1"}
   "opam-file-format" {>= "2.1.2"}
   "sexplib" {>= "v0.14.0"}
   "conf-libev"
@@ -53,7 +53,7 @@ depends: [
   "opam-ci-check"
 ]
 pin-depends: [
-  "opam-ci-check.0.1~dev" "git+https://github.com/ocurrent/opam-ci-check.git#b00f2e016ce6cbc311d488af1aae8d6c8854dfa0"
+  "opam-ci-check.0.1~dev" "git+https://github.com/ocurrent/opam-ci-check.git#c6f883f4500bd69755bcf884a95ccac298cc8c6b"
 ]
 conflicts: [
   "ocaml-migrate-parsetree" {= "1.7.1"}

--- a/opam-repo-ci-web.opam
+++ b/opam-repo-ci-web.opam
@@ -39,8 +39,8 @@ depends: [
   "odoc" {with-doc}
   "capnp-rpc-lwt" {>= "1.2.3"}
   "mula" {>= "0.1.2"}
-  "opam-format" {>= "2.2.0~beta1"}
-  "opam-state" {>= "2.2.0~beta1"}
+  "opam-format" {>= "2.3.0~alpha1"}
+  "opam-state" {>= "2.3.0~alpha1"}
   "ppx_deriving" {>= "5.2.1"}
   "sexplib" {>= "v0.16.0"}
 ]


### PR DESCRIPTION
Also makes a tweak needed to support opam.2.3's breaking changes to `OpamPp.Bad_version`.

This is the corollary of https://github.com/ocurrent/opam-ci-check/issues/42 and
it helps prepare for  https://github.com/tarides/infrastructure/issues/404