### PR TITLE
Add instructions to reproduce linting locally

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -63,6 +63,16 @@ module Check = struct
           | new_ -> ["--newly-published"; String.concat "," new_ ]
     in
     let cmd = ["opam-ci-check"; "lint"; "--opam-repository"; "."] @ changed @ new_ in
+    (* Show instructions to run locally *)
+    let install_instructions = ["opam"; "pin"; "opam-ci-check"; "git+https://github.com/ocurrent/opam-repo-ci.git#live"] in
+    Current.Job.write job
+    (Fmt.str "@.\
+              To reproduce locally, on the opam-repository PR branch, run: @.\
+              @[@;<4 4>%s@]\
+              @[@;<4 4>%s@]@.@."
+     (String.concat " " install_instructions)
+     (String.concat " " cmd));
+    (* Run the lint! *)
     exec ~cwd ~job (cmd |> Array.of_list)
     >>= function
     | Error (`Msg err) ->


### PR DESCRIPTION
Closes #360

would conflict with #367. We can port the instructions to #367 directly, instead of merging this, if that seems better!