### PR TITLE
Replace partially applied `builder` callbacks with a data-oriented approach

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -3,6 +3,8 @@ open Current.Syntax
 module Docker = Current_docker.Default
 module Distro = Dockerfile_opam.Distro
 
+type result = Index.job_ids Current.t * Summary.t Current.t
+
 let master_distro = (Distro.resolve_alias Distro.master_distro :> Distro.t)
 let default_compilers_full = Ocaml_version.Releases.[ v4_14; Ocaml_version.Releases.latest ] (* NOTE: Should probably stay with list length 2 *)
 let default_compilers = List.map Ocaml_version.with_just_major_and_minor default_compilers_full
@@ -196,7 +198,7 @@ let get_base ~arch variant =
 
 let build (module Builder : Build_intf.S)
     ~analysis ~master ~source ~opam_version ~lower_bounds ~revdeps label variant
-  : _ Node.t =
+  : result Node.t =
   let arch = Variant.arch variant in
   let analysis = with_label label analysis in
   let pkgopts =

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -251,14 +251,13 @@ let build (module Builder : Build_intf.S)
   |> (fun x -> Node.branch ~label [x])
   |> Node.collapse ~key:"platform" ~value:label ~input:analysis
 
-let with_cluster ~ocluster ~analysis ~lint ~master source =
+let with_cluster ~ocluster ~analysis ~master source =
   let module Builder : Build_intf.S = struct
     let v = Cluster_build.v ocluster
     let list_revdeps = Cluster_build.list_revdeps ocluster
   end in
   let build = build (module Builder) ~analysis ~master ~source in
   [
-    Node.leaf ~label:"(lint)" (Node.action `Linted lint);
     Node.branch ~label:"compilers" (compilers ~arch:`X86_64 ~build ());
     Node.branch ~label:"distributions" (linux_distributions ~arch:`X86_64 ~build);
     Node.branch ~label:"macos" (macos ~build);
@@ -266,10 +265,7 @@ let with_cluster ~ocluster ~analysis ~lint ~master source =
     Node.branch ~label:"extras" (extras ~build);
   ]
 
-let with_docker ~host_arch ~analysis ~lint ~master source =
+let with_docker ~host_arch ~analysis ~master source =
   let module Builder : Build_intf.S = Local_build in
   let build = build (module Builder) ~analysis ~master ~source in
-  [
-    Node.leaf ~label:"(lint)" (Node.action `Linted lint);
-    Node.branch ~label:"compilers" (compilers ~minimal:true ~arch:host_arch ~build ());
-  ]
+  [Node.branch ~label:"compilers" (compilers ~minimal:true ~arch:host_arch ~build ())]

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -1,58 +1,22 @@
 type result = Index.job_ids Current.t * Summary.t Current.t
 
-val compilers :
-  ?minimal:bool ->
-  arch:Ocaml_version.arch ->
-  build:
-    (opam_version:[> `Dev ] ->
-    lower_bounds:bool ->
-    revdeps:bool ->
-    string ->
-    Variant.t ->
-    'a) ->
-  unit ->
-  'a list
+type build_recipe = {
+  opam_version: Opam_version.t;
+  lower_bounds: bool;
+  revdeps: bool;
+  label: string;
+  variant: Variant.t;
+}
 
-val linux_distributions :
-  arch:Ocaml_version.arch ->
-  build:
-    (opam_version:[> `Dev ] ->
-    lower_bounds:bool ->
-    revdeps:bool ->
-    string ->
-    Variant.t ->
-    'a) ->
-  'a list
+val compilers : ?minimal:bool -> arch:Ocaml_version.arch -> unit -> build_recipe list
 
-val macos :
-  build:
-    (opam_version:[> `Dev ] ->
-    lower_bounds:bool ->
-    revdeps:bool ->
-    string ->
-    Variant.t ->
-    'a) ->
-  'a list
+val linux_distributions : arch:Ocaml_version.arch -> build_recipe list
 
-val freebsd :
-  build:
-    (opam_version:[> `Dev ] ->
-    lower_bounds:bool ->
-    revdeps:bool ->
-    string ->
-    Variant.t ->
-    'a) ->
-  'a list
+val macos : unit -> build_recipe list
 
-val extras :
-  build:
-    (opam_version:Opam_version.t ->
-    lower_bounds:bool ->
-    revdeps:bool ->
-    string ->
-    Variant.t ->
-    'a) ->
-  'a list
+val freebsd : unit -> build_recipe list
+
+val extras : unit -> build_recipe list
 
 (** [with_cluster ~ocluster ~analysis ~master commit] runs all the
     necessary builds for [commit] relative to [master] using a server

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -1,3 +1,5 @@
+type result = Index.job_ids Current.t * Summary.t Current.t
+
 val compilers :
   ?minimal:bool ->
   arch:Ocaml_version.arch ->
@@ -59,7 +61,7 @@ val with_cluster :
   ocluster:Cluster_build.t ->
   analysis:Analyse.Analysis.t Current.t ->
   master:Current_git.Commit.t Current.t ->
-  Current_git.Commit_id.t Current.t -> 'b Node.t list
+  Current_git.Commit_id.t Current.t -> result Node.t list
 
 (** [with_docker ~analysis ~master commit] runs all the necessary builds
     for [commit] relative to [master] using local Docker containers. *)
@@ -67,4 +69,4 @@ val with_docker :
   host_arch:Ocaml_version.arch ->
   analysis:Analyse.Analysis.t Current.t ->
   master:Current_git.Commit.t Current.t ->
-  Current_git.Commit_id.t Current.t -> 'b Node.t list
+  Current_git.Commit_id.t Current.t -> result Node.t list

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -52,21 +52,19 @@ val extras :
     'a) ->
   'a list
 
-(** [with_cluster ~ocluster ~analysis ~lint ~master commit] runs all the
+(** [with_cluster ~ocluster ~analysis ~master commit] runs all the
     necessary builds for [commit] relative to [master] using a server
     cluster through [connection]. *)
 val with_cluster :
   ocluster:Cluster_build.t ->
   analysis:Analyse.Analysis.t Current.t ->
-  lint:unit Current.t ->
   master:Current_git.Commit.t Current.t ->
   Current_git.Commit_id.t Current.t -> 'b Node.t list
 
-(** [with_docker ~analysis ~lint ~master commit] runs all the necessary builds
+(** [with_docker ~analysis ~master commit] runs all the necessary builds
     for [commit] relative to [master] using local Docker containers. *)
 val with_docker :
   host_arch:Ocaml_version.arch ->
   analysis:Analyse.Analysis.t Current.t ->
-  lint:unit Current.t ->
   master:Current_git.Commit.t Current.t ->
   Current_git.Commit_id.t Current.t -> 'b Node.t list

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -120,7 +120,8 @@ let test_pr ~ocluster ~master head =
   let builds =
     Node.root
       (Node.leaf ~label:"(analysis)" (Node.action `Analysed latest_analysis)
-      :: Build.with_cluster ~ocluster ~analysis ~lint ~master commit_id)
+       :: Node.leaf ~label:"(lint)" (Node.action `Linted lint)
+       :: Build.with_cluster ~ocluster ~analysis ~master commit_id)
   in
   summarise ~repo ~hash builds
 
@@ -172,8 +173,9 @@ let local_test_pr ?test_config repo pr_branch () =
   in
   let builds =
     Node.root
-      (Node.leaf ~label:"(analysis)" (Node.action `Analysed analysis)
-      :: Build.with_docker ~host_arch:Conf.host_arch ~analysis ~lint ~master pr_branch_id)
+      ( Node.leaf ~label:"(analysis)" (Node.action `Analysed analysis)
+      :: Node.leaf ~label:"(lint)" (Node.action `Linted lint)
+      :: Build.with_docker ~host_arch:Conf.host_arch ~analysis ~master pr_branch_id )
   in
   summarise ~repo:dummy_repo ~hash:pr_hash builds
   |> Current.ignore_value

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -8,11 +8,11 @@ module Common = Opam_repo_ci_api.Common
 module Distro = Dockerfile_opam.Distro
 
 module Results : sig
-  type t = Index.job_ids Current.t * Summary.t Current.t
+  type t = Build.result
   val empty : t
   val merge : t -> t -> t
 end = struct
-  type t = Index.job_ids Current.t * Summary.t Current.t
+  type t = Build.result
 
   let empty = (Current.return Index.Job_map.empty, Current.return Summary.empty)
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -8,7 +8,7 @@ let specs =
   let pkg = OpamPackage.create (OpamPackage.Name.of_string "a") (OpamPackage.Version.of_string "0.0.1") in
   let revdep = OpamPackage.create (OpamPackage.Name.of_string "b") (OpamPackage.Version.of_string "0.1.0") in
   let arch = `X86_64 in
-  let build ~opam_version ~lower_bounds ~revdeps _s variant =
+  let spec Build.{opam_version; lower_bounds; revdeps; variant; label = _} =
     let image = [ Spec.opam ~variant ~lower_bounds:false ~with_tests:false ~opam_version pkg ] in
     let lower_bounds =
       if lower_bounds then
@@ -27,12 +27,12 @@ let specs =
     in
     image @ lower_bounds @ revdeps
   in
-  List.concat @@
-    (Build.compilers ~arch ~build ()) @
-    (Build.linux_distributions ~arch ~build) @
-    (Build.macos ~build) @
-    (Build.freebsd ~build) @
-    (Build.extras ~build)
+  List.concat_map spec @@
+    Build.compilers ~arch () @
+    Build.linux_distributions ~arch @
+    Build.macos () @
+    Build.freebsd () @
+    Build.extras ()
 
 let header title variant ?(lower_bounds=false) ?(with_tests=false) opam_version =
   let opam_version = "opam-" ^ Opam_version.to_string opam_version in


### PR DESCRIPTION
Towards a composable and intelligible organization of the pipeline
builder code, needed to support factoring out local first logic for
opam-ci-check, this replaces the ubiquitous partially applied `builder`
functions with an approach based on constructing uniform data
structures, which have all the data we need in order to build specs.

FYI @punchagan 

Still to do

- [ ] Rebase after #380 is merged in
- [ ] Additional cleanup/factoring pass
