### PR TITLE
Adjust maintainer contact lint

### DIFF
--- a/opam-ci-check/lib/lint_error.ml
+++ b/opam-ci-check/lib/lint_error.ml
@@ -26,7 +26,7 @@ type error =
   | UnexpectedFile of string
   | ForbiddenPerm of string
   | OpamLint of (int * [ `Warning | `Error ] * string)
-  | MaintainerEmailMissing of string
+  | MaintainerWithoutContact of string list
   | FailedToDownload of string
   | NameCollision of string
   | WeakChecksum of string
@@ -149,11 +149,12 @@ let msg_of_error (package, (err : error)) =
   | OpamLint warn ->
       let warn = OpamFileTools.warns_to_string [ warn ] in
       Printf.sprintf "Error in %s: %s" pkg warn
-  | MaintainerEmailMissing maintainer ->
+  | MaintainerWithoutContact maintainer ->
       Printf.sprintf
-        "Error in %s: Maintainer email missing. Please add a maintainer email \
-         to the opam file. Maintainer: %s"
-        pkg maintainer
+        "Error in %s: There is no way to contact the maintainer(s) '%s'. A package \
+         must either specify a url for 'bug-reports' or provide an email \
+         address in the 'maintainer' field."
+        pkg (String.concat ", " maintainer)
   | ParseError ->
       Printf.sprintf "Error in %s: Failed to parse the opam file" pkg
   | DefaultTagsPresent tags ->

--- a/opam-ci-check/test/lint.t
+++ b/opam-ci-check/test/lint.t
@@ -198,10 +198,11 @@ Add multiple maintainers with no email and remove the bug-reports field from a
 valid package:
 
   $ git reset -q --hard initial-state
-  $ sed -i \
+  $ sed \
   > -e 's/maintainer.*/maintainer: ["Maintainer1" "Maintaner2"]/' \
   > -e '/bug-reports.*/d' \
-  > packages/a-1/a-1.0.0.1/opam
+  > packages/a-1/a-1.0.0.1/opam > opam.new
+  $ mv opam.new packages/a-1/a-1.0.0.1/opam
   $ git diff packages/a-1/a-1.0.0.1/opam | grep '^[+-][^+-]'
   -maintainer: "Maintainer <me@example.com>"
   +maintainer: ["Maintainer1" "Maintaner2"]
@@ -218,9 +219,10 @@ Test that we report the expected linting error:
 Add one email to the maintainers, and ensure it now passes the maintainer
 contact lint:
 
-  $ sed -i \
+  $ sed \
   > -e 's/"Maintaner2"/"Maintaner2 <me@example.com>"/' \
-  > packages/a-1/a-1.0.0.1/opam
+  > packages/a-1/a-1.0.0.1/opam > opam.new
+  $ mv opam.new packages/a-1/a-1.0.0.1/opam
   $ git diff packages/a-1/a-1.0.0.1/opam | grep '^[+-][^+-]'
   -maintainer: "Maintainer <me@example.com>"
   +maintainer: ["Maintainer1" "Maintaner2 <me@example.com>"]
@@ -234,9 +236,10 @@ Just remove the email address, leaving the bug-reports and ensure that it now
 passes linting:
 
   $ git reset -q --hard initial-state
-  $ sed -i \
+  $ sed \
   > -e 's/maintainer.*/maintainer: ["Maintainer1" "Maintaner2"]/' \
-  > packages/a-1/a-1.0.0.1/opam
+  > packages/a-1/a-1.0.0.1/opam > opam.new
+  $ mv opam.new packages/a-1/a-1.0.0.1/opam
   $ git diff packages/a-1/a-1.0.0.1/opam | grep '^[+-][^+-]'
   -maintainer: "Maintainer <me@example.com>"
   +maintainer: ["Maintainer1" "Maintaner2"]

--- a/test/lint.t
+++ b/test/lint.t
@@ -31,11 +31,7 @@ Tests the following:
   $ opam-repo-ci-local --repo="." --branch=new-branch-1 --lint-only --no-web-server
   Error "Warning in system-b.0.0.1: package name has restricted prefix 'system-'
   Error in system-b.0.0.1: package with prefix 'system-' requires conflict class 'ocaml-system'
-  Error in system-b.0.0.1: Maintainer email missing. Please add a maintainer email to the opam file. Maintainer: Maintainer
   Error in b.0.0.3: package with conflict class 'ocaml-host-arch' requires name prefix 'host-arch-'
   Error in b.0.0.3: pin-depends present. This is not allowed in the opam-repository.
-  Error in b.0.0.3: Maintainer email missing. Please add a maintainer email to the opam file. Maintainer: Maintainer
-  Error in b.0.0.2: Maintainer email missing. Please add a maintainer email to the opam file. Maintainer: Maintainer
   Error in b.0.0.2:              error  3: File format error in 'unknown-field' at line 11, column 0: Invalid field unknown-field
-  Error in b.0.0.1: Maintainer email missing. Please add a maintainer email to the opam file. Maintainer: Maintainer
   Error in b.0.0.1:            warning 25: Missing field 'authors'"


### PR DESCRIPTION
Closes https://github.com/ocaml/infrastructure/issues/152 by addressing
the subsequenst requests for tweaked behavior.

With this change in place, the lint will only fail if there is no email address
at all in the `maintainer` field AND no bug-tracker. We already issue a warning
when no bug-tracker is present, and since we currently make no distinction
between errors and warnings in our CI results, this check is made somewhat
redundant. However, once https://github.com/ocurrent/opam-repo-ci/issues/328 is
introduced, the distinction here will make a difference.