### PR TITLE
Don't fail analysis on new directories in the root

### DIFF
--- a/test/analyse.t
+++ b/test/analyse.t
@@ -111,6 +111,15 @@ See https://github.com/ocurrent/opam-repo-ci/issues/291
   $ opam-repo-ci-local --repo="." --branch=analyze-invalid-opam-file --analyse-only --no-web-server
   Error ""packages/a-1/a-1.0.0.1/opam" failed to be parsed: '.' is not a valid token"
 
-Clean up the build cache
+  $ rm -rf var
 
-  $ rm -rf ./var
+Test that a new root directory can be created.
+See https://github.com/ocurrent/opam-repo-ci/pull/397
+
+  $ git checkout -q -b add-a-new-dir initial-state
+  $ mkdir a-new-directory
+  $ touch a-new-directory/foo
+  $ git add  a-new-directory/foo
+  $ git commit -q -m "Add a new directory"
+  $ opam-repo-ci-local --repo="." --branch=add-a-new-dir --analyse-only --no-web-server
+  { "packages": [] }


### PR DESCRIPTION
The current analysis logic is overly restrictive in processing the directory structure of the repository: it only allows for the subdirectories `.github` and `packages`. The addition of any other subdirectory will result in an error like 

```
Job failed: Unexpected path "some/path" in output (expecting 'packages/name/pkg/...')
```

This is causing the analysis to fail on https://github.com/ocaml/opam-repository/pull/26992.

The view taken in this change is that the addition of files in new subdirectories other than `packages/` should be reviewed as normal PRs to the
code base.

A more restrictive view could be taken  that requires any additional directories be white-listed in advance. I am open to entertaining that view, and adopting that approach instead, if needed, but I don't see a good reason to be so restrictive currently.

cc @mseri and @hannesm