### PR TITLE
Use 0install solver

### DIFF
--- a/opam-ci-check/lib/opam_build.ml
+++ b/opam-ci-check/lib/opam_build.ml
@@ -115,7 +115,7 @@ let setup_repository ?(local=false) ~variant ~for_docker ~opam_version () =
      Otherwise the "opam pin" after the "opam repository set-url" will fail (cannot find the new package for some reason) *)
   run "%s -f %s/bin/opam-%s %s/bin/opam" ln prefix opam_version_str prefix ::
   run ~network "opam init --reinit%s -ni" opamrc :: (* TODO: Remove ~network when https://github.com/ocurrent/ocaml-dockerfile/pull/132 is merged *)
-  run "opam option solver=builtin-0install && opam config report" ::
+  run "%sopam config report" (match opam_version with `V2_1 | `V2_2 | `V2_3 | `Dev -> "opam option solver=builtin-0install && " | `V2_0 -> "") ::
   env "OPAMDOWNLOADJOBS" "1" :: (* Try to avoid github spam detection *)
   env "OPAMERRLOGLEN" "0" :: (* Show the whole log if it fails *)
   env "OPAMPRECISETRACKING" "1" :: (* Mitigate https://github.com/ocaml/opam/issues/3997 *)

--- a/opam-ci-check/test/build.t
+++ b/opam-ci-check/test/build.t
@@ -6,10 +6,9 @@ Test the build command:
   WORKDIR /home/opam
   RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
   RUN opam init --reinit -ni
-  RUN uname -rs && opam exec -- ocaml -version && opam --version
+  RUN opam option solver=builtin-0install && opam config report
   ENV OPAMDOWNLOADJOBS="1"
   ENV OPAMERRLOGLEN="0"
-  ENV OPAMSOLVERTIMEOUT="1000"
   ENV OPAMPRECISETRACKING="1"
   ENV CI="true"
   ENV OPAM_REPO_CI="true"
@@ -57,10 +56,9 @@ Test the build command:
   WORKDIR /home/opam
   RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
   RUN opam init --reinit -ni
-  RUN uname -rs && opam exec -- ocaml -version && opam --version
+  RUN opam option solver=builtin-0install && opam config report
   ENV OPAMDOWNLOADJOBS="1"
   ENV OPAMERRLOGLEN="0"
-  ENV OPAMSOLVERTIMEOUT="1000"
   ENV OPAMPRECISETRACKING="1"
   ENV CI="true"
   ENV OPAM_REPO_CI="true"
@@ -92,10 +90,9 @@ Test the build command:
   WORKDIR /home/opam
   RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
   RUN opam init --reinit -ni
-  RUN uname -rs && opam exec -- ocaml -version && opam --version
+  RUN opam option solver=builtin-0install && opam config report
   ENV OPAMDOWNLOADJOBS="1"
   ENV OPAMERRLOGLEN="0"
-  ENV OPAMSOLVERTIMEOUT="1000"
   ENV OPAMPRECISETRACKING="1"
   ENV CI="true"
   ENV OPAM_REPO_CI="true"
@@ -122,7 +119,6 @@ Test the build command:
   ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
   ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
   ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-  RUN opam option solver=builtin-0install
   RUN opam reinstall conf-pkg-config.4; \
       res=$?; \
       test "$res" != 31 && exit "$res"; \
@@ -146,10 +142,9 @@ Test the build command:
   WORKDIR /home/opam
   RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
   RUN opam init --reinit -ni
-  RUN uname -rs && opam exec -- ocaml -version && opam --version
+  RUN opam option solver=builtin-0install && opam config report
   ENV OPAMDOWNLOADJOBS="1"
   ENV OPAMERRLOGLEN="0"
-  ENV OPAMSOLVERTIMEOUT="1000"
   ENV OPAMPRECISETRACKING="1"
   ENV CI="true"
   ENV OPAM_REPO_CI="true"

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -4,10 +4,9 @@ build: debian-12-ocaml-4.02/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -38,10 +37,9 @@ build: debian-12-ocaml-4.02/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -68,7 +66,6 @@ build: debian-12-ocaml-4.02/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -91,10 +88,9 @@ build: debian-12-ocaml-4.03/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -125,10 +121,9 @@ build: debian-12-ocaml-4.03/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -155,7 +150,6 @@ build: debian-12-ocaml-4.03/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -178,10 +172,9 @@ build: debian-12-ocaml-4.04/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -212,10 +205,9 @@ build: debian-12-ocaml-4.04/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -242,7 +234,6 @@ build: debian-12-ocaml-4.04/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -265,10 +256,9 @@ build: debian-12-ocaml-4.05/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -299,10 +289,9 @@ build: debian-12-ocaml-4.05/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -329,7 +318,6 @@ build: debian-12-ocaml-4.05/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -352,10 +340,9 @@ build: debian-12-ocaml-4.06/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -386,10 +373,9 @@ build: debian-12-ocaml-4.06/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -416,7 +402,6 @@ build: debian-12-ocaml-4.06/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -439,10 +424,9 @@ build: debian-12-ocaml-4.07/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -473,10 +457,9 @@ build: debian-12-ocaml-4.07/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -503,7 +486,6 @@ build: debian-12-ocaml-4.07/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -526,10 +508,9 @@ build: debian-12-ocaml-4.08/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -560,10 +541,9 @@ build: debian-12-ocaml-4.08/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -590,7 +570,6 @@ build: debian-12-ocaml-4.08/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -613,10 +592,9 @@ build: debian-12-ocaml-4.09/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -647,10 +625,9 @@ build: debian-12-ocaml-4.09/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -677,7 +654,6 @@ build: debian-12-ocaml-4.09/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -700,10 +676,9 @@ build: debian-12-ocaml-4.10/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -734,10 +709,9 @@ build: debian-12-ocaml-4.10/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -764,7 +738,6 @@ build: debian-12-ocaml-4.10/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -787,10 +760,9 @@ build: debian-12-ocaml-4.11/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -821,10 +793,9 @@ build: debian-12-ocaml-4.11/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -851,7 +822,6 @@ build: debian-12-ocaml-4.11/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -874,10 +844,9 @@ build: debian-12-ocaml-4.12/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -908,10 +877,9 @@ build: debian-12-ocaml-4.12/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -938,7 +906,6 @@ build: debian-12-ocaml-4.12/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -961,10 +928,9 @@ build: debian-12-ocaml-4.13/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -995,10 +961,9 @@ build: debian-12-ocaml-4.13/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1025,7 +990,6 @@ build: debian-12-ocaml-4.13/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -1048,10 +1012,9 @@ build: debian-12-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1082,10 +1045,9 @@ build: debian-12-ocaml-4.14/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1112,7 +1074,6 @@ build: debian-12-ocaml-4.14/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -1135,10 +1096,9 @@ list-revdeps: debian-12-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1154,10 +1114,9 @@ build: debian-12-ocaml-4.14/amd64 opam-dev with-tests
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1204,10 +1163,9 @@ build: debian-12-ocaml-5.0/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1238,10 +1196,9 @@ build: debian-12-ocaml-5.0/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1268,7 +1225,6 @@ build: debian-12-ocaml-5.0/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -1291,10 +1247,9 @@ build: debian-12-ocaml-5.1/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1325,10 +1280,9 @@ build: debian-12-ocaml-5.1/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1355,7 +1309,6 @@ build: debian-12-ocaml-5.1/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -1378,10 +1331,9 @@ build: debian-12-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1412,10 +1364,9 @@ build: debian-12-ocaml-5.2/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1442,7 +1393,6 @@ build: debian-12-ocaml-5.2/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -1465,10 +1415,9 @@ list-revdeps: debian-12-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1484,10 +1433,9 @@ build: debian-12-ocaml-5.2/amd64 opam-dev with-tests
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1534,10 +1482,9 @@ build: debian-12-ocaml-5.3-beta1/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1568,10 +1515,9 @@ build: debian-12-ocaml-5.3-beta1/amd64 opam-dev lower-bounds
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1598,7 +1544,6 @@ build: debian-12-ocaml-5.3-beta1/amd64 opam-dev lower-bounds
     ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
     ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN opam option solver=builtin-0install
     RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
@@ -1621,10 +1566,9 @@ build: ubuntu-24.10-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1655,10 +1599,9 @@ build: ubuntu-24.04-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1689,10 +1632,9 @@ build: ubuntu-22.04-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1723,10 +1665,9 @@ build: ubuntu-20.04-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1757,10 +1698,9 @@ build: opensuse-tumbleweed-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1791,10 +1731,9 @@ build: opensuse-15.6-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1825,10 +1764,9 @@ build: fedora-41-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1859,10 +1797,9 @@ build: fedora-40-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1893,10 +1830,9 @@ build: debian-unstable-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1927,10 +1863,9 @@ build: debian-testing-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1961,10 +1896,9 @@ build: debian-11-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -1995,10 +1929,9 @@ build: archlinux-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2029,10 +1962,9 @@ build: alpine-3.20-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2063,10 +1995,9 @@ build: ubuntu-24.10-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2097,10 +2028,9 @@ build: ubuntu-24.04-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2131,10 +2061,9 @@ build: ubuntu-22.04-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2165,10 +2094,9 @@ build: ubuntu-20.04-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2199,10 +2127,9 @@ build: opensuse-tumbleweed-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2233,10 +2160,9 @@ build: opensuse-15.6-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2267,10 +2193,9 @@ build: fedora-41-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2301,10 +2226,9 @@ build: fedora-40-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2335,10 +2259,9 @@ build: debian-unstable-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2369,10 +2292,9 @@ build: debian-testing-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2403,10 +2325,9 @@ build: debian-11-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2437,10 +2358,9 @@ build: archlinux-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2471,10 +2391,9 @@ build: alpine-3.20-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2504,10 +2423,9 @@ build: macos-homebrew-ocaml-5.2/amd64 opam-dev
     USER 1000:1000
     RUN ln -f ~/local/bin/opam-dev ~/local/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2537,10 +2455,9 @@ build: macos-homebrew-ocaml-5.2/arm64 opam-dev
     USER 1000:1000
     RUN ln -f ~/local/bin/opam-dev ~/local/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2570,10 +2487,9 @@ build: macos-homebrew-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     RUN ln -f ~/local/bin/opam-dev ~/local/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2603,10 +2519,9 @@ build: macos-homebrew-ocaml-4.14/arm64 opam-dev
     USER 1000:1000
     RUN ln -f ~/local/bin/opam-dev ~/local/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2637,10 +2552,9 @@ build: freebsd-ocaml-5.2/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/local/bin/opam-dev /usr/local/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2671,10 +2585,9 @@ build: freebsd-ocaml-4.14/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/local/bin/opam-dev /usr/local/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2705,10 +2618,9 @@ build: debian-12-ocaml-5.2/amd64 opam-2.0
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.0 /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2739,10 +2651,9 @@ build: debian-12-ocaml-5.2/amd64 opam-2.1
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2773,10 +2684,9 @@ build: debian-12-ocaml-5.2/amd64 opam-2.2
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.2 /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2807,10 +2717,9 @@ build: debian-12-ocaml-5.2/amd64 opam-2.3
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.3 /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2841,10 +2750,9 @@ build: debian-12-ocaml-5.2-afl/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2875,10 +2783,9 @@ build: debian-12-ocaml-5.2-flambda/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2909,10 +2816,9 @@ build: debian-12-ocaml-5.2-no-flat-float-array/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2944,10 +2850,9 @@ build: debian-12-ocaml-5.2/i386 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -2978,10 +2883,9 @@ build: debian-12-ocaml-5.2/arm64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3012,10 +2916,9 @@ build: debian-12-ocaml-5.2/ppc64le opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3047,10 +2950,9 @@ build: debian-12-ocaml-5.2/arm32v7 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3081,10 +2983,9 @@ build: debian-12-ocaml-5.2/s390x opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3115,10 +3016,9 @@ build: ubuntu-24.04-ocaml-5.2/riscv64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3149,10 +3049,9 @@ build: debian-12-ocaml-4.14/amd64 opam-2.0
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.0 /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3183,10 +3082,9 @@ build: debian-12-ocaml-4.14/amd64 opam-2.1
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3217,10 +3115,9 @@ build: debian-12-ocaml-4.14/amd64 opam-2.2
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.2 /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3251,10 +3148,9 @@ build: debian-12-ocaml-4.14/amd64 opam-2.3
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.3 /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3285,10 +3181,9 @@ build: debian-12-ocaml-4.14-afl/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3319,10 +3214,9 @@ build: debian-12-ocaml-4.14-flambda/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3353,10 +3247,9 @@ build: debian-12-ocaml-4.14-fp/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3387,10 +3280,9 @@ build: debian-12-ocaml-4.14-flambda-fp/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3421,10 +3313,9 @@ build: debian-12-ocaml-4.14-no-flat-float-array/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3455,10 +3346,9 @@ build: debian-12-ocaml-4.14-nnp/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3489,10 +3379,9 @@ build: debian-12-ocaml-4.14-nnpchecker/amd64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3524,10 +3413,9 @@ build: debian-12-ocaml-4.14/i386 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3558,10 +3446,9 @@ build: debian-12-ocaml-4.14/arm64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3592,10 +3479,9 @@ build: debian-12-ocaml-4.14/ppc64le opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3627,10 +3513,9 @@ build: debian-12-ocaml-4.14/arm32v7 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3661,10 +3546,9 @@ build: debian-12-ocaml-4.14/s390x opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"
@@ -3695,10 +3579,9 @@ build: ubuntu-24.04-ocaml-4.14/riscv64 opam-dev
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN uname -rs && opam exec -- ocaml -version && opam --version
+    RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
-    ENV OPAMSOLVERTIMEOUT="1000"
     ENV OPAMPRECISETRACKING="1"
     ENV CI="true"
     ENV OPAM_REPO_CI="true"

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -2618,7 +2618,7 @@ build: debian-12-ocaml-5.2/amd64 opam-2.0
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.0 /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
+    RUN opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
     ENV OPAMPRECISETRACKING="1"
@@ -3049,7 +3049,7 @@ build: debian-12-ocaml-4.14/amd64 opam-2.0
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.0 /usr/bin/opam
     RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
+    RUN opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
     ENV OPAMPRECISETRACKING="1"


### PR DESCRIPTION
We continue to see solver timeouts as reported by @mseri and collated [here](https://github.com/mtelvers/solver-timeouts).  This PR changes the default solver from mccs to 0install, which is the plan for future versions of opam.

I initially tried increasing the timeout again from 1000 to 1500, but even this was not long enough in some cases.

I have previously argued against changing the solver as this would make the CI differ from the user experience. However, users must already be mitigating this, as I do not expect they are waiting more than 25 minutes for a solution. The default timeout is 60 seconds!

Since opam-repo-ci is testing the instability of the package, maintainers will likely be ignoring cases where the solver times out.  Therefore, it would be more useful to get results than fail on the timeout.  Furthermore, this should speed things along as the 0install is much faster.