### PR TITLE
Switch to using opam-ci-check to generate the list of revdeps

### DIFF
--- a/lib/ci_check_ref.ml
+++ b/lib/ci_check_ref.ml
@@ -1,0 +1,2 @@
+(* The commit hash of the opam-ci-check executable to use in pipelines *)
+let v = "07ac60a4667898154fa64730eb59592edc255512"

--- a/lib/dune
+++ b/lib/dune
@@ -1,3 +1,19 @@
+; TODO: comment explaining this workaround
+
+(rule
+ (deps %{bin:opam-ci-check})
+ (action
+  (progn
+   (with-stdout-to
+    ci_check_ref.ml.out
+    (pipe-stdout
+     (run git rev-parse HEAD)
+     (run
+      xargs
+      printf
+      "(* The commit hash of the opam-ci-check executable to use in pipelines *)\nlet v = \"%s\"\n")))
+   (diff ci_check_ref.ml ci_check_ref.ml.out))))
+
 (library
  (name opam_repo_ci)
  (package opam-repo-ci-api)

--- a/opam-ci-check/lib/opam_build.mli
+++ b/opam-ci-check/lib/opam_build.mli
@@ -13,6 +13,7 @@ val spec :
 
 val revdeps :
   ?local:bool ->
+  ?ci_check_ref:string ->
   for_docker:bool ->
   opam_version:Opam_version.t ->
   base:string ->
@@ -20,10 +21,13 @@ val revdeps :
   pkg:OpamPackage.t ->
   unit ->
   Obuilder_spec.t
+(** @param ci_check_ref a git ref for the opam-ci-check package to pin when listing revdeps *)
 
 val build_spec :
   ?local:bool ->
+  ?ci_check_ref:string ->
   for_docker:bool ->
   base:Spec.base  ->
   Spec.t ->
   Obuilder_spec.t
+(** @param ci_check_ref a git ref for the opam-ci-check package to pin when listing revdeps *)

--- a/opam-ci-check/lib/revdeps.ml
+++ b/opam-ci-check/lib/revdeps.ml
@@ -46,7 +46,6 @@ let non_transitive_revdeps st package_set =
      not of random local things that a user may have installed in their system.
 
      See https://github.com/ocaml/opam/blob/b3d2f5c554e6ef3cc736a9f97e252486403e050f/src/client/opamCommands.ml#L729-L731 *)
-  let all_known_packages = st.OpamStateTypes.packages in
   let packages_depending_on_target_packages revdep_candidate_pkg =
     let dependancy_on =
       revdep_candidate_pkg |> opam_file_of_package st
@@ -55,8 +54,9 @@ let non_transitive_revdeps st package_set =
     in
     OpamPackage.Set.exists dependancy_on package_set
   in
+  let available_packages = Lazy.force st.OpamStateTypes.available_packages in
   OpamPackage.Set.filter packages_depending_on_target_packages
-    all_known_packages
+    available_packages
 
 let list_revdeps ?(opam_repo = "https://opam.ocaml.org") ?(transitive = true)
     ?(use_default_root = false) pkg =

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -1106,7 +1106,8 @@ list-revdeps: debian-12-ocaml-4.14/amd64 opam-dev
     COPY --chown=1000:1000 . opam-repository/
     RUN opam repository set-url --strict default opam-repository/
     RUN opam update --depexts || true
-    RUN echo '@@@OUTPUT' && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --depopts && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --recursive && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --with-test --depopts && echo '@@@OUTPUT'
+    RUN opam pin add -k git -y opam-ci-check git+https://github.com/ocurrent/opam-repo-ci.git#live
+    RUN echo '@@@OUTPUT' && opam exec -- opam-ci-check list --use-default-root 'a.0.0.1' && echo '@@@OUTPUT'
 
 build: debian-12-ocaml-4.14/amd64 opam-dev with-tests
     FROM BASE_IMAGE_TAG
@@ -1425,7 +1426,8 @@ list-revdeps: debian-12-ocaml-5.2/amd64 opam-dev
     COPY --chown=1000:1000 . opam-repository/
     RUN opam repository set-url --strict default opam-repository/
     RUN opam update --depexts || true
-    RUN echo '@@@OUTPUT' && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --depopts && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --recursive && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --with-test --depopts && echo '@@@OUTPUT'
+    RUN opam pin add -k git -y opam-ci-check git+https://github.com/ocurrent/opam-repo-ci.git#live
+    RUN echo '@@@OUTPUT' && opam exec -- opam-ci-check list --use-default-root 'a.0.0.1' && echo '@@@OUTPUT'
 
 build: debian-12-ocaml-5.2/amd64 opam-dev with-tests
     FROM BASE_IMAGE_TAG

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -1106,7 +1106,7 @@ list-revdeps: debian-12-ocaml-4.14/amd64 opam-dev
     COPY --chown=1000:1000 . opam-repository/
     RUN opam repository set-url --strict default opam-repository/
     RUN opam update --depexts || true
-    RUN opam pin add -k git -y opam-ci-check git+https://github.com/ocurrent/opam-repo-ci.git#live
+    RUN opam pin add -k git -y opam-ci-check git+https://github.com/ocurrent/opam-repo-ci.git#07ac60a4667898154fa64730eb59592edc255512
     RUN echo '@@@OUTPUT' && opam exec -- opam-ci-check list --use-default-root 'a.0.0.1' && echo '@@@OUTPUT'
 
 build: debian-12-ocaml-4.14/amd64 opam-dev with-tests
@@ -1426,7 +1426,7 @@ list-revdeps: debian-12-ocaml-5.2/amd64 opam-dev
     COPY --chown=1000:1000 . opam-repository/
     RUN opam repository set-url --strict default opam-repository/
     RUN opam update --depexts || true
-    RUN opam pin add -k git -y opam-ci-check git+https://github.com/ocurrent/opam-repo-ci.git#live
+    RUN opam pin add -k git -y opam-ci-check git+https://github.com/ocurrent/opam-repo-ci.git#07ac60a4667898154fa64730eb59592edc255512
     RUN echo '@@@OUTPUT' && opam exec -- opam-ci-check list --use-default-root 'a.0.0.1' && echo '@@@OUTPUT'
 
 build: debian-12-ocaml-5.2/amd64 opam-dev with-tests
@@ -1958,7 +1958,7 @@ build: archlinux-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: alpine-3.21-ocaml-5.2/amd64 opam-dev
+build: alpine-3.20-ocaml-5.2/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1983,7 +1983,7 @@ build: alpine-3.21-ocaml-5.2/amd64 opam-dev
         failed=$(ls "$build_dir"); \
         partial_fails=""; \
         for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"alpine-3.21\""; then \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"alpine-3.20\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
@@ -2387,7 +2387,7 @@ build: archlinux-ocaml-4.14/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: alpine-3.21-ocaml-4.14/amd64 opam-dev
+build: alpine-3.20-ocaml-4.14/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2412,7 +2412,7 @@ build: alpine-3.21-ocaml-4.14/amd64 opam-dev
         failed=$(ls "$build_dir"); \
         partial_fails=""; \
         for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"alpine-3.21\""; then \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"alpine-3.20\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \

--- a/test/test.ml
+++ b/test/test.ml
@@ -81,6 +81,7 @@ let dump () =
     | `Opam (`List_revdeps lr, pkg) ->
       let spec_str =
         Opam_build.revdeps
+          ~ci_check_ref:Opam_repo_ci.Ci_check_ref.v
           ~for_docker:true
           ~opam_version:lr.opam_version
           ~base


### PR DESCRIPTION
Closes https://github.com/tarides/infrastructure/issues/422

This PR switches to using opam-ci-check to list reverse dependencies from the 3 command opam list invocation we previously had. The output is slightly different from the previous output in that it contains only available packages instead of all packages.  The PR also changes `opam-ci-check` CLI to accept an additional `use-default-root` argument to prevent creating a new opam root for running it's commands. 