### PR TITLE
opam_ci_check: Add option to use default opam root instead of creating new one

### DIFF
--- a/opam-ci-check/lib/env.ml
+++ b/opam-ci-check/lib/env.ml
@@ -42,15 +42,12 @@ let create_local_switch_maybe repo_path =
     ()
   in
   (* FIXME: reinit if already exists? *)
-  if not (OpamFilename.exists_dir root_dir) then
-    match repo_path with
-    | Some d ->
-        OpamConsole.msg
-          "Creating local opam switch in %s with default repository URL %s\n"
-          (OpamFilename.Dir.to_string root_dir)
-          d;
-        create_switch_dir d
-    | None -> failwith "Opam local repository path must be specified!"
+  if not (OpamFilename.exists_dir root_dir) then (
+    OpamConsole.msg
+      "Creating local opam switch in %s with default repository URL %s\n"
+      (OpamFilename.Dir.to_string root_dir)
+      repo_path;
+    create_switch_dir repo_path)
   else ()
 
 let with_locked_switch () =

--- a/opam-ci-check/lib/env.ml
+++ b/opam-ci-check/lib/env.ml
@@ -7,12 +7,12 @@ let make_repo path =
   let repo_url = OpamUrl.parse path in
   { OpamTypes.repo_name; repo_url; repo_trust = None }
 
-let local_opam_root () =
-  let switch_dir = ".opam-revdeps" in
+let get_opam_root ?(use_default_root = false) () =
+  let switch_dir = if use_default_root then "~/.opam" else ".opam-revdeps" in
   OpamFilename.Dir.of_string switch_dir
 
-let create_local_switch_maybe repo_path =
-  let root_dir = local_opam_root () in
+let create_local_switch_maybe ?(use_default_root = false) repo_path =
+  let root_dir = get_opam_root ~use_default_root () in
   let create_switch_dir repo_path =
     OpamClientConfig.opam_init ~root_dir ();
     (* opam init*)
@@ -50,14 +50,14 @@ let create_local_switch_maybe repo_path =
     create_switch_dir repo_path)
   else ()
 
-let with_locked_switch () =
-  let root_dir = local_opam_root () in
+let with_locked_switch ?(use_default_root = false) () =
+  let root_dir = get_opam_root ~use_default_root () in
   OpamClientConfig.opam_init ~root_dir ();
   OpamGlobalState.with_ `Lock_none @@ fun gt ->
   OpamSwitchState.with_ `Lock_write gt
 
-let with_unlocked_switch () =
-  let root_dir = local_opam_root () in
+let with_unlocked_switch ?(use_default_root = false) () =
+  let root_dir = get_opam_root ~use_default_root () in
   OpamClientConfig.opam_init ~root_dir ();
   OpamGlobalState.with_ `Lock_none @@ fun gt ->
   OpamSwitchState.with_ `Lock_none gt

--- a/opam-ci-check/lib/revdeps.ml
+++ b/opam-ci-check/lib/revdeps.ml
@@ -62,7 +62,6 @@ let list_revdeps ?(opam_repo = "https://opam.ocaml.org") ?(transitive = true)
     pkg =
   (* Create local opam root and switch *)
   Env.create_local_switch_maybe opam_repo;
-  OpamConsole.msg "Listing revdeps for %s\n" pkg;
   let package = OpamPackage.of_string pkg in
   let package_set = OpamPackage.Set.singleton package in
   Env.with_unlocked_switch () (fun st ->
@@ -89,7 +88,6 @@ let find_latest_versions packages =
 module Display = struct
   let packages packages =
     packages
-    |> List.iter (fun p -> OpamConsole.msg "%s\n" (OpamPackage.to_string p));
-    OpamConsole.msg "Number of reverse dependencies: %d\n"
-      (List.length packages)
+    |> List.sort_uniq OpamPackage.compare
+    |> List.iter (fun p -> OpamConsole.msg "%s\n" (OpamPackage.to_string p))
 end

--- a/opam-ci-check/lib/revdeps.ml
+++ b/opam-ci-check/lib/revdeps.ml
@@ -61,7 +61,7 @@ let non_transitive_revdeps st package_set =
 let list_revdeps ?(opam_repo = "https://opam.ocaml.org") ?(transitive = true)
     pkg =
   (* Create local opam root and switch *)
-  Env.create_local_switch_maybe (Some opam_repo);
+  Env.create_local_switch_maybe opam_repo;
   OpamConsole.msg "Listing revdeps for %s\n" pkg;
   let package = OpamPackage.of_string pkg in
   let package_set = OpamPackage.Set.singleton package in

--- a/opam-ci-check/lib/revdeps.ml
+++ b/opam-ci-check/lib/revdeps.ml
@@ -59,12 +59,12 @@ let non_transitive_revdeps st package_set =
     all_known_packages
 
 let list_revdeps ?(opam_repo = "https://opam.ocaml.org") ?(transitive = true)
-    pkg =
-  (* Create local opam root and switch *)
-  Env.create_local_switch_maybe opam_repo;
+    ?(use_default_root = false) pkg =
+  (* Create local opam root and switch if required *)
+  if not use_default_root then Env.create_local_switch_maybe opam_repo;
   let package = OpamPackage.of_string pkg in
   let package_set = OpamPackage.Set.singleton package in
-  Env.with_unlocked_switch () (fun st ->
+  Env.with_unlocked_switch ~use_default_root () (fun st ->
       let transitive_deps =
         if transitive then transitive_revdeps st package_set
         else OpamPackage.Set.empty

--- a/opam-ci-check/lib/revdeps.mli
+++ b/opam-ci-check/lib/revdeps.mli
@@ -5,7 +5,11 @@
 (** Analyze and test the reverse dependencies of a package. *)
 
 val list_revdeps :
-  ?opam_repo:string -> ?transitive:bool -> string -> OpamPackage.t list
+  ?opam_repo:string ->
+  ?transitive:bool ->
+  ?use_default_root:bool ->
+  string ->
+  OpamPackage.t list
 (** [list_revdeps pkg] is a list of the transitive reverse dependencies of [pkg].
 
     @param opam_repo The package repository to use when calculating
@@ -13,6 +17,9 @@ val list_revdeps :
 
     @param transitive Whether or to list all transitive reverse dependencies.
     Defaults to [true].
+
+    @param use_default_root Whether or to use the default root ~/.opam or
+    create a new one. Defaults to [false].
 
     @param pkg The package for which reverse dependencies will be listed, in a
     form like ["pkgname.0.0.1"].

--- a/opam-ci-check/lib/test.ml
+++ b/opam-ci-check/lib/test.ml
@@ -32,7 +32,8 @@ let test_package_with_opam_in_state st revdep =
          But, we may be able to do better, since we are not a shell script? *)
       Some (revdep, e)
 
-let test_packages_with_opam target_pkg revdeps_list =
+let test_packages_with_opam ?(use_default_root = false) target_pkg revdeps_list
+    =
   let target = OpamPackage.of_string target_pkg in
   match
     OpamConsole.confirm "Do you want test %d revdeps?"
@@ -44,7 +45,7 @@ let test_packages_with_opam target_pkg revdeps_list =
         ~confirm_level:`unsafe_yes (* Don't prompt for install / remove *) ();
       OpamConsole.msg "Installing reverse dependencies with pinned %s\n"
         (OpamPackage.to_string target);
-      Env.with_locked_switch () @@ fun st ->
+      Env.with_locked_switch ~use_default_root () @@ fun st ->
       let st' = OpamClient.install st [ pkg_atom target ] in
       revdeps_list |> List.to_seq
       |> Seq.filter_map (test_package_with_opam_in_state st')

--- a/opam-ci-check/lib/test.mli
+++ b/opam-ci-check/lib/test.mli
@@ -7,7 +7,8 @@ type error = OpamPackage.t * exn
 
 val error_to_string : error -> string
 
-val test_packages_with_opam : string -> OpamPackage.t list -> error Seq.t
+val test_packages_with_opam :
+  ?use_default_root:bool -> string -> OpamPackage.t list -> error Seq.t
 (** [test_packages_with_opam package revdeps] is the sequence of errors encountered
     while trying to install and test all the packages in [revdeps].
 


### PR DESCRIPTION
This PR adds a CLI option to run the opam-ci-check revdeps related commands using the default opam-root instead of creating a new one. This makes the revdeps functionality easier to use in our CI images. 

The PR also has a couple of minor preparatory commits to make it easier to use the revdeps listing command in CI. 