### PR TITLE
Fetch each package into its own directory when linting

### DIFF
--- a/opam-ci-check/bin/main.ml
+++ b/opam-ci-check/bin/main.ml
@@ -72,7 +72,11 @@ let lint package_specs local_repo_dir =
       let process_package { pkg; src; newly_published } =
         let opam = read_package_opam ~opam_repo_dir pkg in
         let pkg_src_dir =
-          if Option.is_none src then fetch_package_src ~dir ~pkg opam else src
+          if Option.is_none src then
+            let dir = dir // OpamPackage.to_string pkg in
+            fetch_package_src ~dir ~pkg opam
+          else
+            src
         in
         Lint.v ~pkg ~newly_published ~pkg_src_dir opam
       in


### PR DESCRIPTION
Closes #405

Follows @punchagan's comment at https://github.com/ocurrent/opam-repo-ci/issues/405#issuecomment-2549278971

I've tested locally that this works on
https://github.com/ocaml/opam-repository/pull/27138