### PR TITLE
opam-ci-check: Command to list-revdeps in docker image

### DIFF
--- a/opam-ci-check/lib/spec.ml
+++ b/opam-ci-check/lib/spec.ml
@@ -37,6 +37,10 @@ let opam ?revdep ~variant ~lower_bounds ~with_tests ~opam_version pkg =
   let ty = `Opam (`Build { revdep; lower_bounds; with_tests; opam_version }, pkg) in
   { variant; ty }
 
+let opam_list_revdeps ~variant ~opam_version pkg =
+  let ty = `Opam (`List_revdeps { opam_version }, pkg) in
+  { variant; ty }
+
 let pp_pkg ?revdep f pkg =
   match revdep with
   | Some revdep -> Fmt.pf f "%s with %s" (OpamPackage.to_string revdep) (OpamPackage.to_string pkg)

--- a/opam-ci-check/lib/spec.mli
+++ b/opam-ci-check/lib/spec.mli
@@ -39,6 +39,11 @@ val opam :
   lower_bounds:bool ->
   with_tests:bool -> opam_version:Opam_version.t -> package -> t
 
+(** Generate configuration for a [list_revdeps] job *)
+val opam_list_revdeps :
+  variant:Variant.t ->
+  opam_version:Opam_version.t -> package -> t
+
 val pp_ty :
   Format.formatter ->
   [< `Opam of


### PR DESCRIPTION
The `opam-ci-check list` command can be run locally to list revdeps for a package. It creates an isolated opam root for some isolation, but for a greater extent of isolation, this commit adds a list-revdeps command that can be used to list-revdeps locally using a Docker image.
