### PR TITLE
Update ocaml-version and ocaml-dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ocaml/opam:debian-12-ocaml-4.14 AS build
 RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && opam init --reinit -ni
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto graphviz m4 pkg-config libsqlite3-dev libgmp-dev libffi-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard 2dff29abd6cda0706f80503db11dd4af4e7db559 && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 20f04c842252bdb1bd98bbe0f9c813f203d2b5dc && opam update
 COPY --chown=opam opam-repo-ci-service.opam opam-repo-ci-api.opam opam-ci-check.opam /src/
 WORKDIR /src
 RUN opam install -y --deps-only .

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,7 +1,7 @@
 FROM ocaml/opam:debian-12-ocaml-4.14 AS build
 RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && opam init --reinit -ni
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev libffi-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard 65a1519b6d82a358204a1a33b6d84821d56da6bd && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 20f04c842252bdb1bd98bbe0f9c813f203d2b5dc && opam update
 COPY --chown=opam opam-repo-ci-api.opam opam-repo-ci-web.opam opam-repo-ci-service.opam opam-ci-check.opam /src/
 WORKDIR /src
 RUN opam install -y --deps-only .

--- a/doc/platforms.md
+++ b/doc/platforms.md
@@ -54,21 +54,21 @@
 - 5.0
 - 5.1
 - 5.2
-- 5.2-afl
-- 5.2-flambda
-- 5.2-no-flat-float-array
-- 5.3~rc1
+- 5.3
+- 5.3-afl
+- 5.3-flambda
+- 5.3-no-flat-float-array
 
 ## Platforms Matrix
 
 |  OS | Arch | OCaml version |Opam version | Test lower-bounds | Test reverse dependencies |
 | --- | --- | --- | --- | --- | --- |
 | alpine-3.21 | amd64 | 4.14 | dev | No | No |
-| alpine-3.21 | amd64 | 5.2 | dev | No | No |
+| alpine-3.21 | amd64 | 5.3 | dev | No | No |
 | archlinux | amd64 | 4.14 | dev | No | No |
-| archlinux | amd64 | 5.2 | dev | No | No |
+| archlinux | amd64 | 5.3 | dev | No | No |
 | debian-11 | amd64 | 4.14 | dev | No | No |
-| debian-11 | amd64 | 5.2 | dev | No | No |
+| debian-11 | amd64 | 5.3 | dev | No | No |
 | debian-12 | amd64 | 4.02 | dev | Yes | No |
 | debian-12 | amd64 | 4.03 | dev | Yes | No |
 | debian-12 | amd64 | 4.04 | dev | Yes | No |
@@ -91,46 +91,46 @@
 | debian-12 | amd64 | 4.14-no-flat-float-array | dev | No | No |
 | debian-12 | amd64 | 5.0 | dev | Yes | No |
 | debian-12 | amd64 | 5.1 | dev | Yes | No |
-| debian-12 | amd64 | 5.2 | dev | Yes | Yes |
-| debian-12 | amd64 | 5.2-afl | dev | No | No |
-| debian-12 | amd64 | 5.2-flambda | dev | No | No |
-| debian-12 | amd64 | 5.2-no-flat-float-array | dev | No | No |
-| debian-12 | amd64 | 5.3~rc1 | dev | Yes | No |
+| debian-12 | amd64 | 5.2 | dev | Yes | No |
+| debian-12 | amd64 | 5.3 | dev | Yes | Yes |
+| debian-12 | amd64 | 5.3-afl | dev | No | No |
+| debian-12 | amd64 | 5.3-flambda | dev | No | No |
+| debian-12 | amd64 | 5.3-no-flat-float-array | dev | No | No |
 | debian-12 | arm32v7 | 4.14 | dev | No | No |
-| debian-12 | arm32v7 | 5.2 | dev | No | No |
+| debian-12 | arm32v7 | 5.3 | dev | No | No |
 | debian-12 | arm64 | 4.14 | dev | No | No |
-| debian-12 | arm64 | 5.2 | dev | No | No |
+| debian-12 | arm64 | 5.3 | dev | No | No |
 | debian-12 | i386 | 4.14 | dev | No | No |
-| debian-12 | i386 | 5.2 | dev | No | No |
+| debian-12 | i386 | 5.3 | dev | No | No |
 | debian-12 | ppc64le | 4.14 | dev | No | No |
-| debian-12 | ppc64le | 5.2 | dev | No | No |
+| debian-12 | ppc64le | 5.3 | dev | No | No |
 | debian-12 | s390x | 4.14 | dev | No | No |
-| debian-12 | s390x | 5.2 | dev | No | No |
+| debian-12 | s390x | 5.3 | dev | No | No |
 | debian-testing | amd64 | 4.14 | dev | No | No |
-| debian-testing | amd64 | 5.2 | dev | No | No |
+| debian-testing | amd64 | 5.3 | dev | No | No |
 | debian-unstable | amd64 | 4.14 | dev | No | No |
-| debian-unstable | amd64 | 5.2 | dev | No | No |
+| debian-unstable | amd64 | 5.3 | dev | No | No |
 | fedora-40 | amd64 | 4.14 | dev | No | No |
-| fedora-40 | amd64 | 5.2 | dev | No | No |
+| fedora-40 | amd64 | 5.3 | dev | No | No |
 | fedora-41 | amd64 | 4.14 | dev | No | No |
-| fedora-41 | amd64 | 5.2 | dev | No | No |
+| fedora-41 | amd64 | 5.3 | dev | No | No |
 | freebsd | amd64 | 4.14 | dev | No | No |
-| freebsd | amd64 | 5.2 | dev | No | No |
+| freebsd | amd64 | 5.3 | dev | No | No |
 | macos-homebrew | amd64 | 4.14 | dev | No | No |
-| macos-homebrew | amd64 | 5.2 | dev | No | No |
+| macos-homebrew | amd64 | 5.3 | dev | No | No |
 | macos-homebrew | arm64 | 4.14 | dev | No | No |
-| macos-homebrew | arm64 | 5.2 | dev | No | No |
+| macos-homebrew | arm64 | 5.3 | dev | No | No |
 | opensuse-15.6 | amd64 | 4.14 | dev | No | No |
-| opensuse-15.6 | amd64 | 5.2 | dev | No | No |
+| opensuse-15.6 | amd64 | 5.3 | dev | No | No |
 | opensuse-tumbleweed | amd64 | 4.14 | dev | No | No |
-| opensuse-tumbleweed | amd64 | 5.2 | dev | No | No |
+| opensuse-tumbleweed | amd64 | 5.3 | dev | No | No |
 | ubuntu-20.04 | amd64 | 4.14 | dev | No | No |
-| ubuntu-20.04 | amd64 | 5.2 | dev | No | No |
+| ubuntu-20.04 | amd64 | 5.3 | dev | No | No |
 | ubuntu-22.04 | amd64 | 4.14 | dev | No | No |
-| ubuntu-22.04 | amd64 | 5.2 | dev | No | No |
+| ubuntu-22.04 | amd64 | 5.3 | dev | No | No |
 | ubuntu-24.04 | amd64 | 4.14 | dev | No | No |
-| ubuntu-24.04 | amd64 | 5.2 | dev | No | No |
+| ubuntu-24.04 | amd64 | 5.3 | dev | No | No |
 | ubuntu-24.04 | riscv64 | 4.14 | dev | No | No |
-| ubuntu-24.04 | riscv64 | 5.2 | dev | No | No |
+| ubuntu-24.04 | riscv64 | 5.3 | dev | No | No |
 | ubuntu-24.10 | amd64 | 4.14 | dev | No | No |
-| ubuntu-24.10 | amd64 | 5.2 | dev | No | No |
+| ubuntu-24.10 | amd64 | 5.3 | dev | No | No |

--- a/opam-ci-check/test/build.t
+++ b/opam-ci-check/test/build.t
@@ -51,7 +51,7 @@ Test the build command:
   
 
   $ opam-ci-check build lwt.5.7.0 --only-print
-  FROM ocaml/opam:debian-12-ocaml-5.2
+  FROM ocaml/opam:debian-12-ocaml-5.3
   USER 1000:1000
   WORKDIR /home/opam
   RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -1409,74 +1409,7 @@ build: debian-12-ocaml-5.2/amd64 opam-dev lower-bounds
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-list-revdeps: debian-12-ocaml-5.2/amd64 opam-dev
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN echo '@@@OUTPUT' && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --depopts && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --recursive && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --with-test --depopts && echo '@@@OUTPUT'
-
-build: debian-12-ocaml-5.2/amd64 opam-dev with-tests
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-    RUN (opam reinstall --with-test a.0.0.1) || true
-    RUN opam reinstall --with-test --verbose a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-12-ocaml-5.3-rc1/amd64 opam-dev
+build: debian-12-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1509,7 +1442,7 @@ build: debian-12-ocaml-5.3-rc1/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-12-ocaml-5.3-rc1/amd64 opam-dev lower-bounds
+build: debian-12-ocaml-5.3/amd64 opam-dev lower-bounds
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1560,7 +1493,74 @@ build: debian-12-ocaml-5.3-rc1/amd64 opam-dev lower-bounds
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: ubuntu-24.10-ocaml-5.2/amd64 opam-dev
+list-revdeps: debian-12-ocaml-5.3/amd64 opam-dev
+    FROM BASE_IMAGE_TAG
+    USER 1000:1000
+    WORKDIR /home/opam
+    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
+    RUN opam init --reinit -ni
+    RUN opam option solver=builtin-0install && opam config report
+    ENV OPAMDOWNLOADJOBS="1"
+    ENV OPAMERRLOGLEN="0"
+    ENV OPAMPRECISETRACKING="1"
+    ENV CI="true"
+    ENV OPAM_REPO_CI="true"
+    RUN rm -rf opam-repository/
+    COPY --chown=1000:1000 . opam-repository/
+    RUN opam repository set-url --strict default opam-repository/
+    RUN opam update --depexts || true
+    RUN echo '@@@OUTPUT' && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --depopts && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --recursive && opam list -s --color=never --depends-on 'a.0.0.1' --coinstallable-with 'a.0.0.1' --all-versions --with-test --depopts && echo '@@@OUTPUT'
+
+build: debian-12-ocaml-5.3/amd64 opam-dev with-tests
+    FROM BASE_IMAGE_TAG
+    USER 1000:1000
+    WORKDIR /home/opam
+    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
+    RUN opam init --reinit -ni
+    RUN opam option solver=builtin-0install && opam config report
+    ENV OPAMDOWNLOADJOBS="1"
+    ENV OPAMERRLOGLEN="0"
+    ENV OPAMPRECISETRACKING="1"
+    ENV CI="true"
+    ENV OPAM_REPO_CI="true"
+    RUN rm -rf opam-repository/
+    COPY --chown=1000:1000 . opam-repository/
+    RUN opam repository set-url --strict default opam-repository/
+    RUN opam update --depexts || true
+    RUN opam pin add -k version -yn a.0.0.1 0.0.1
+    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
+        res=$?; \
+        test "$res" != 31 && exit "$res"; \
+        export OPAMCLI=2.0; \
+        build_dir=$(opam var prefix)/.opam-switch/build; \
+        failed=$(ls "$build_dir"); \
+        partial_fails=""; \
+        for pkg in $failed; do \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
+        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+        fi; \
+        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
+        done; \
+        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+        exit 1
+    RUN (opam reinstall --with-test a.0.0.1) || true
+    RUN opam reinstall --with-test --verbose a.0.0.1; \
+        res=$?; \
+        test "$res" != 31 && exit "$res"; \
+        export OPAMCLI=2.0; \
+        build_dir=$(opam var prefix)/.opam-switch/build; \
+        failed=$(ls "$build_dir"); \
+        partial_fails=""; \
+        for pkg in $failed; do \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
+        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+        fi; \
+        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
+        done; \
+        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+        exit 1
+
+build: ubuntu-24.10-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1593,7 +1593,7 @@ build: ubuntu-24.10-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: ubuntu-24.04-ocaml-5.2/amd64 opam-dev
+build: ubuntu-24.04-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1626,7 +1626,7 @@ build: ubuntu-24.04-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: ubuntu-22.04-ocaml-5.2/amd64 opam-dev
+build: ubuntu-22.04-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1659,7 +1659,7 @@ build: ubuntu-22.04-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: ubuntu-20.04-ocaml-5.2/amd64 opam-dev
+build: ubuntu-20.04-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1692,7 +1692,7 @@ build: ubuntu-20.04-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: opensuse-tumbleweed-ocaml-5.2/amd64 opam-dev
+build: opensuse-tumbleweed-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1725,7 +1725,7 @@ build: opensuse-tumbleweed-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: opensuse-15.6-ocaml-5.2/amd64 opam-dev
+build: opensuse-15.6-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1758,7 +1758,7 @@ build: opensuse-15.6-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: fedora-41-ocaml-5.2/amd64 opam-dev
+build: fedora-41-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1791,7 +1791,7 @@ build: fedora-41-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: fedora-40-ocaml-5.2/amd64 opam-dev
+build: fedora-40-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1824,7 +1824,7 @@ build: fedora-40-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-unstable-ocaml-5.2/amd64 opam-dev
+build: debian-unstable-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1857,7 +1857,7 @@ build: debian-unstable-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-testing-ocaml-5.2/amd64 opam-dev
+build: debian-testing-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1890,7 +1890,7 @@ build: debian-testing-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-11-ocaml-5.2/amd64 opam-dev
+build: debian-11-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1923,7 +1923,7 @@ build: debian-11-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: archlinux-ocaml-5.2/amd64 opam-dev
+build: archlinux-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1956,7 +1956,7 @@ build: archlinux-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: alpine-3.21-ocaml-5.2/amd64 opam-dev
+build: alpine-3.21-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2418,7 +2418,7 @@ build: alpine-3.21-ocaml-4.14/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: macos-homebrew-ocaml-5.2/amd64 opam-dev
+build: macos-homebrew-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     RUN ln -f ~/local/bin/opam-dev ~/local/bin/opam
@@ -2450,7 +2450,7 @@ build: macos-homebrew-ocaml-5.2/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: macos-homebrew-ocaml-5.2/arm64 opam-dev
+build: macos-homebrew-ocaml-5.3/arm64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     RUN ln -f ~/local/bin/opam-dev ~/local/bin/opam
@@ -2546,7 +2546,7 @@ build: macos-homebrew-ocaml-4.14/arm64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: freebsd-ocaml-5.2/amd64 opam-dev
+build: freebsd-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2612,7 +2612,7 @@ build: freebsd-ocaml-4.14/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-12-ocaml-5.2/amd64 opam-2.0
+build: debian-12-ocaml-5.3/amd64 opam-2.0
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2645,7 +2645,7 @@ build: debian-12-ocaml-5.2/amd64 opam-2.0
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-12-ocaml-5.2/amd64 opam-2.1
+build: debian-12-ocaml-5.3/amd64 opam-2.1
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2678,7 +2678,7 @@ build: debian-12-ocaml-5.2/amd64 opam-2.1
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-12-ocaml-5.2/amd64 opam-2.2
+build: debian-12-ocaml-5.3/amd64 opam-2.2
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2711,7 +2711,7 @@ build: debian-12-ocaml-5.2/amd64 opam-2.2
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-12-ocaml-5.2/amd64 opam-2.3
+build: debian-12-ocaml-5.3/amd64 opam-2.3
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2744,7 +2744,7 @@ build: debian-12-ocaml-5.2/amd64 opam-2.3
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-12-ocaml-5.2-afl/amd64 opam-dev
+build: debian-12-ocaml-5.3-afl/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2777,7 +2777,7 @@ build: debian-12-ocaml-5.2-afl/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-12-ocaml-5.2-flambda/amd64 opam-dev
+build: debian-12-ocaml-5.3-flambda/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2810,7 +2810,7 @@ build: debian-12-ocaml-5.2-flambda/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-12-ocaml-5.2-no-flat-float-array/amd64 opam-dev
+build: debian-12-ocaml-5.3-no-flat-float-array/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2843,107 +2843,7 @@ build: debian-12-ocaml-5.2-no-flat-float-array/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-12-ocaml-5.2/i386 opam-dev
-    FROM BASE_IMAGE_TAG
-    SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-12-ocaml-5.2/arm64 opam-dev
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-12-ocaml-5.2/ppc64le opam-dev
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-12-ocaml-5.2/arm32v7 opam-dev
+build: debian-12-ocaml-5.3/i386 opam-dev
     FROM BASE_IMAGE_TAG
     SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
     USER 1000:1000
@@ -2977,7 +2877,7 @@ build: debian-12-ocaml-5.2/arm32v7 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-12-ocaml-5.2/s390x opam-dev
+build: debian-12-ocaml-5.3/arm64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -3010,7 +2910,107 @@ build: debian-12-ocaml-5.2/s390x opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: ubuntu-24.04-ocaml-5.2/riscv64 opam-dev
+build: debian-12-ocaml-5.3/ppc64le opam-dev
+    FROM BASE_IMAGE_TAG
+    USER 1000:1000
+    WORKDIR /home/opam
+    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
+    RUN opam init --reinit -ni
+    RUN opam option solver=builtin-0install && opam config report
+    ENV OPAMDOWNLOADJOBS="1"
+    ENV OPAMERRLOGLEN="0"
+    ENV OPAMPRECISETRACKING="1"
+    ENV CI="true"
+    ENV OPAM_REPO_CI="true"
+    RUN rm -rf opam-repository/
+    COPY --chown=1000:1000 . opam-repository/
+    RUN opam repository set-url --strict default opam-repository/
+    RUN opam update --depexts || true
+    RUN opam pin add -k version -yn a.0.0.1 0.0.1
+    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
+        res=$?; \
+        test "$res" != 31 && exit "$res"; \
+        export OPAMCLI=2.0; \
+        build_dir=$(opam var prefix)/.opam-switch/build; \
+        failed=$(ls "$build_dir"); \
+        partial_fails=""; \
+        for pkg in $failed; do \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
+        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+        fi; \
+        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
+        done; \
+        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+        exit 1
+
+build: debian-12-ocaml-5.3/arm32v7 opam-dev
+    FROM BASE_IMAGE_TAG
+    SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+    USER 1000:1000
+    WORKDIR /home/opam
+    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
+    RUN opam init --reinit -ni
+    RUN opam option solver=builtin-0install && opam config report
+    ENV OPAMDOWNLOADJOBS="1"
+    ENV OPAMERRLOGLEN="0"
+    ENV OPAMPRECISETRACKING="1"
+    ENV CI="true"
+    ENV OPAM_REPO_CI="true"
+    RUN rm -rf opam-repository/
+    COPY --chown=1000:1000 . opam-repository/
+    RUN opam repository set-url --strict default opam-repository/
+    RUN opam update --depexts || true
+    RUN opam pin add -k version -yn a.0.0.1 0.0.1
+    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
+        res=$?; \
+        test "$res" != 31 && exit "$res"; \
+        export OPAMCLI=2.0; \
+        build_dir=$(opam var prefix)/.opam-switch/build; \
+        failed=$(ls "$build_dir"); \
+        partial_fails=""; \
+        for pkg in $failed; do \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
+        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+        fi; \
+        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
+        done; \
+        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+        exit 1
+
+build: debian-12-ocaml-5.3/s390x opam-dev
+    FROM BASE_IMAGE_TAG
+    USER 1000:1000
+    WORKDIR /home/opam
+    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
+    RUN opam init --reinit -ni
+    RUN opam option solver=builtin-0install && opam config report
+    ENV OPAMDOWNLOADJOBS="1"
+    ENV OPAMERRLOGLEN="0"
+    ENV OPAMPRECISETRACKING="1"
+    ENV CI="true"
+    ENV OPAM_REPO_CI="true"
+    RUN rm -rf opam-repository/
+    COPY --chown=1000:1000 . opam-repository/
+    RUN opam repository set-url --strict default opam-repository/
+    RUN opam update --depexts || true
+    RUN opam pin add -k version -yn a.0.0.1 0.0.1
+    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
+        res=$?; \
+        test "$res" != 31 && exit "$res"; \
+        export OPAMCLI=2.0; \
+        build_dir=$(opam var prefix)/.opam-switch/build; \
+        failed=$(ls "$build_dir"); \
+        partial_fails=""; \
+        for pkg in $failed; do \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
+        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+        fi; \
+        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
+        done; \
+        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+        exit 1
+
+build: ubuntu-24.04-ocaml-5.3/riscv64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam


### PR DESCRIPTION
Updates ocaml-version to 3.7.2 and ocaml-dockerfile to 8.2.5 which will test on OCaml 5.3.0 and Alpine 3.21.

Closes https://github.com/ocurrent/opam-repo-ci/issues/413.

Wait for base images to build before merging.