### PR TITLE
Add version number to FreeBSD

### DIFF
--- a/doc/platforms.md
+++ b/doc/platforms.md
@@ -10,7 +10,7 @@
 - debian-unstable
 - fedora-40
 - fedora-41
-- freebsd
+- freebsd-14.1
 - macos-homebrew
 - opensuse-15.6
 - opensuse-tumbleweed
@@ -114,8 +114,8 @@
 | fedora-40 | amd64 | 5.3 | dev | No | No |
 | fedora-41 | amd64 | 4.14 | dev | No | No |
 | fedora-41 | amd64 | 5.3 | dev | No | No |
-| freebsd | amd64 | 4.14 | dev | No | No |
-| freebsd | amd64 | 5.3 | dev | No | No |
+| freebsd-14.1 | amd64 | 4.14 | dev | No | No |
+| freebsd-14.1 | amd64 | 5.3 | dev | No | No |
 | macos-homebrew | amd64 | 4.14 | dev | No | No |
 | macos-homebrew | amd64 | 5.3 | dev | No | No |
 | macos-homebrew | arm64 | 4.14 | dev | No | No |

--- a/opam-ci-check/lib/variant.ml
+++ b/opam-ci-check/lib/variant.ml
@@ -27,7 +27,7 @@ let docker_tag t =
 let distribution t = t.distribution
 let pp f t = Fmt.pf f "%s/%s" (docker_tag t) (Ocaml_version.string_of_arch t.arch)
 
-let freebsd = "freebsd"
+let freebsd = "freebsd-14.1"
 let macos_homebrew = "macos-homebrew"
 
 let macos_distributions = [
@@ -39,7 +39,7 @@ let macos_distributions = [
 let os { distribution; _ } =
   if List.exists (String.equal distribution) macos_distributions then
     `Macos
-  else if List.exists (String.equal distribution) [ "freebsd" ] then
+  else if List.exists (String.equal distribution) [ freebsd ] then
     `Freebsd
   else
     `Linux

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -2546,7 +2546,7 @@ build: macos-homebrew-ocaml-4.14/arm64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: freebsd-ocaml-5.3/amd64 opam-dev
+build: freebsd-14.1-ocaml-5.3/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2571,7 +2571,7 @@ build: freebsd-ocaml-5.3/amd64 opam-dev
         failed=$(ls "$build_dir"); \
         partial_fails=""; \
         for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"freebsd\""; then \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"freebsd-14.1\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
@@ -2579,7 +2579,7 @@ build: freebsd-ocaml-5.3/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: freebsd-ocaml-4.14/amd64 opam-dev
+build: freebsd-14.1-ocaml-4.14/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2604,7 +2604,7 @@ build: freebsd-ocaml-4.14/amd64 opam-dev
         failed=$(ls "$build_dir"); \
         partial_fails=""; \
         for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"freebsd\""; then \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"freebsd-14.1\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \


### PR DESCRIPTION
The FreeBSD images have been renamed from `freebsd-ocaml-x.y` to `freebsd-14.1-ocaml-x.y` (https://github.com/ocurrent/freebsd-infra/pull/11).  This PR updates `opam-repo-ci` to use the new image names.

Closes https://github.com/ocaml/infrastructure/issues/168 and https://github.com/ocurrent/opam-repo-ci/issues/277.