### PR TITLE
Don't raise a linting error on conf- packages without sources

### DIFF
--- a/opam-ci-check.opam
+++ b/opam-ci-check.opam
@@ -26,7 +26,7 @@ depends: [
   "opam-client" {>= "2.3.0~alpha1"}
   "ocaml-version" {>= "3.7.3"}
   "dockerfile-opam" {>= "6.3.0"}
-  "obuilder-spec"
+  "obuilder-spec" {>= "0.2"}
   "odoc" {with-doc}
   "ppx_deriving" {>= "5.2.1"}
   "ppx_deriving_yojson"

--- a/opam-ci-check/lint/lint_error.ml
+++ b/opam-ci-check/lint/lint_error.ml
@@ -39,6 +39,7 @@ type error =
   | MissingUpperBound of string
   | InvalidReasonForArchiving
   | InvalidOpamRepositoryCommitHash
+  | InvalidConfPackage of [`Conf_prefix | `Depext | `Conf_flag] list
 
 (**/**)
 
@@ -189,3 +190,17 @@ let msg_of_error (package, (err : error)) =
          recording the commit hash of the primary repo at the time the package \
          version is archived."
         pkg x_opam_repository_commit_hash_at_time_of_archiving_field
+  | InvalidConfPackage properties ->
+    let property_descriptions =
+      properties
+      |> List.map (function
+          | `Conf_flag -> "the 'conf' flag"
+          | `Conf_prefix -> "the 'conf-' name prefix"
+          | `Depext -> "a non-empty 'depext' field")
+      |> String.concat " and "
+    in
+    Printf.sprintf
+      "Error in %s: conf packages should always use the 'conf-' name prefix, \
+       the 'conf' flag, and the 'depext' field all together, but this \
+       package only has %s"
+      pkg property_descriptions

--- a/opam-ci-check/test/lint.t
+++ b/opam-ci-check/test/lint.t
@@ -509,3 +509,88 @@ has an invald value:
   Linting opam-repository at $TESTCASE_ROOT/. ...
   Error in a-1.0.0.1: The field 'x-opam-repository-commit-hash-at-time-of-archiving' must be present and hold a string recording the commit hash of the primary repo at the time the package version is archived.
   [1]
+
+## conf- package checks
+
+Reset the project repo
+
+  $ git reset -q --hard initial-state
+
+Test that a package with a conf- prefix but missing the `conf` flag and `depext`
+field triggers the expected lint errors:
+
+  $ export INVALID_CONF_DIR=packages/conf-invalid/conf-invalid.0.0.1/
+  $ mkdir -p $INVALID_CONF_DIR
+  $ cat > $INVALID_CONF_DIR/opam <<EOF
+  > opam-version: "2.0"
+  > synopsis: "Synopsis"
+  > description: "Description"
+  > maintainer: "Maintainer <me@example.com>"
+  > author: "Author"
+  > license: "Apache-2.0"
+  > homepage: "https://github.com/ocurrent/opam-repo-ci"
+  > bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
+  > dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
+  > doc: "https://ocurrent.github.io/ocurrent/"
+  > build: []
+  > depends: []
+  > EOF
+  $ opam-ci-check lint -r . conf-invalid.0.0.1
+  Linting opam-repository at $TESTCASE_ROOT/. ...
+  Error in conf-invalid.0.0.1: No package source directory provided.
+  Error in conf-invalid.0.0.1: conf packages should always use the 'conf-' name prefix, the 'conf' flag, and the 'depext' field all together, but this package only has the 'conf-' name prefix
+  [1]
+  $ git reset -q --hard initial-state
+
+Test that a package with a conf- prefix and `depext` feild, but missing the
+`conf` flag, triggers the expected lint errors:
+
+  $ export INVALID_CONF_DIR=packages/conf-invalid/conf-invalid.0.0.2/
+  $ mkdir -p $INVALID_CONF_DIR
+  $ cat > $INVALID_CONF_DIR/opam <<EOF
+  > opam-version: "2.0"
+  > synopsis: "Synopsis"
+  > description: "Description"
+  > maintainer: "Maintainer <me@example.com>"
+  > author: "Author"
+  > license: "Apache-2.0"
+  > homepage: "https://github.com/ocurrent/opam-repo-ci"
+  > bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
+  > dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
+  > doc: "https://ocurrent.github.io/ocurrent/"
+  > build: []
+  > depends: []
+  > depexts: [ "curl" ]
+  > EOF
+  $ opam-ci-check lint -r . conf-invalid.0.0.2
+  Linting opam-repository at $TESTCASE_ROOT/. ...
+  Error in conf-invalid.0.0.2: No package source directory provided.
+  Error in conf-invalid.0.0.2: conf packages should always use the 'conf-' name prefix, the 'conf' flag, and the 'depext' field all together, but this package only has the 'conf-' name prefix and a non-empty 'depext' field
+  [1]
+  $ git reset -q --hard initial-state
+
+Test that a valid conf- package triggers no linting errors (in particular, a
+valid conf package should not trigger 'No package source directory provided'):
+
+  $ export VALID_CONF_DIR=packages/conf-valid/conf-valid.0.0.1/
+  $ mkdir -p $VALID_CONF_DIR
+  $ cat > $VALID_CONF_DIR/opam <<EOF
+  > opam-version: "2.0"
+  > synopsis: "Synopsis"
+  > description: "Description"
+  > maintainer: "Maintainer <me@example.com>"
+  > author: "Author"
+  > license: "Apache-2.0"
+  > homepage: "https://github.com/ocurrent/opam-repo-ci"
+  > bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
+  > dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
+  > doc: "https://ocurrent.github.io/ocurrent/"
+  > build: []
+  > depends: []
+  > depexts: [ "curl" ]
+  > flags: [ conf ]
+  > EOF
+  $ opam-ci-check lint -r . conf-valid.0.0.1
+  Linting opam-repository at $TESTCASE_ROOT/. ...
+  No errors
+  $ git reset -q --hard initial-state

--- a/opam-ci-check/test/lint.t
+++ b/opam-ci-check/test/lint.t
@@ -163,11 +163,11 @@ Test the following:
   [1]
   $ opam-ci-check lint -r . b.0.0.3:new=false
   Linting opam-repository at $TESTCASE_ROOT/. ...
-  Error in b.0.0.3: Your dune-project file indicates that this package requires at least dune 3.16 but your opam file only requires dune >= 3.15.0. Please check which requirement is the right one, and fix the other.
   Error in b.0.0.3: Weak checksum algorithm(s) provided. Please use SHA-256 or SHA-512. Details: opam field extra-files contains only MD5 as checksum for 0install.install
   Error in b.0.0.3: pin-depends present. This is not allowed in the opam-repository.
   Error in b.0.0.3: extra-files present. This is not allowed in the opam-repository. Please use extra-source instead.
   Error in b.0.0.3: package with conflict class 'ocaml-host-arch' requires name prefix 'host-arch-'
+  Error in b.0.0.3: Your dune-project file indicates that this package requires at least dune 3.16 but your opam file only requires dune >= 3.15.0. Please check which requirement is the right one, and fix the other.
   [1]
   $ opam-ci-check lint -r . system-b.0.0.1:new=false
   Linting opam-repository at $TESTCASE_ROOT/. ...
@@ -279,8 +279,8 @@ Test presence of unexpected files in a-1.0.0.2 package
 
   $ opam-ci-check lint -r . a-1.0.0.2:new=false
   Linting opam-repository at $TESTCASE_ROOT/. ...
-  Error in a-1.0.0.2: No package source directory provided.
   Error in a-1.0.0.2: Unexpected file in packages/a-1/a-1.0.0.2/files
+  Error in a-1.0.0.2: No package source directory provided.
   [1]
 
 Setup repo for Forbidden perm file
@@ -297,8 +297,8 @@ Test presence of unexpected files in a-1.0.0.2 package
 
   $ opam-ci-check lint -r . a-1.0.0.2:new=false
   Linting opam-repository at $TESTCASE_ROOT/. ...
-  Error in a-1.0.0.2: No package source directory provided.
   Error in a-1.0.0.2: Forbidden permission for file packages/a-1/a-1.0.0.2/opam. All files should have permissions 644.
+  Error in a-1.0.0.2: No package source directory provided.
   [1]
 
 # Maintainer contact lint

--- a/opam-repo-ci-api.opam
+++ b/opam-repo-ci-api.opam
@@ -25,7 +25,7 @@ depends: [
   "current_ocluster"
   "logs"
   "mula" {>= "0.1.2"}
-  "obuilder-spec"
+  "obuilder-spec" {>= "0.2"}
   "ocaml-version" {>= "3.7.3"}
   "opam-format" {>= "2.3.0~alpha1"}
   "opam-state" {>= "2.3.0~alpha1"}


### PR DESCRIPTION
Closes #420 

The linting checks of conf- packages currently suffer from two related problems:

1. We incorrectly signal linting when package sources are missing, even tho conf- packages should (generally) not have sources.
2. There is no check to ensure that conf- packages are correctly specified, as per the opam manual.

The [opam manual stipulates](https://opam.ocaml.org/doc/Manual.html#opamflag-conf) that

> the package may not include a source URL or install anything, but just do some checks, and fail to install if they don't pass. conf packages should have a name starting with conf-, and include the appropriate [depexts:](https://opam.ocaml.org/doc/Manual.html#opamfield-depexts) field

This PR fixes (1) by adding an exception to the checks for the presence of sources, and fixes (2) by adding a check to ensure that conf- packages are specified correctly.

cc: @zapashcanon, @mseri, @raphael-proust