### PR TITLE
Improve parse errors in linting check

### DIFF
--- a/opam-ci-check/bin/main.ml
+++ b/opam-ci-check/bin/main.ml
@@ -49,12 +49,11 @@ let read_package_opam ~opam_repo_dir pkg =
   In_channel.with_open_text opam_path @@ fun ic ->
   try OpamFile.OPAM.read_from_channel ic
   with
-  | OpamPp.Bad_format ((_, msg) : OpamPp.bad_format)
-  | OpamPp.Bad_version (((_, msg) : OpamPp.bad_format), _)
-  ->
-    Printf.eprintf "Error in %s: Failed to parse the opam file due to '%s'"
-      opam_path msg;
-    exit 1
+  | exn ->
+    (Printf.eprintf "Error in %s: failed to parse opam file:\n'%s'\n"
+      opam_path
+      (OpamPp.string_of_bad_format ~file:opam_path exn);
+    exit 1)
 
 type package_spec = {
   pkg : OpamPackage.t;

--- a/opam-ci-check/test/lint.t
+++ b/opam-ci-check/test/lint.t
@@ -184,7 +184,9 @@ Test the following:
   [1]
   $ opam-ci-check lint -r . b.0.0.6:new=false
   Linting opam-repository at $TESTCASE_ROOT/. ...
-  Error in $TESTCASE_ROOT/./packages/b/b.0.0.6/opam: Failed to parse the opam file due to 'Parse error'
+  Error in $TESTCASE_ROOT/./packages/b/b.0.0.6/opam: failed to parse opam file:
+  'At ./<none>:13:12-13:13::
+  Parse error'
   [1]
   $ opam-ci-check lint -r . b.0.0.7:new=false
   Linting opam-repository at $TESTCASE_ROOT/. ...
@@ -196,7 +198,9 @@ Test the following:
 The quiet flag still allows output when there is an error:
 
   $ opam-ci-check lint -r . --quiet b.0.0.6:new=false
-  Error in $TESTCASE_ROOT/./packages/b/b.0.0.6/opam: Failed to parse the opam file due to 'Parse error'
+  Error in $TESTCASE_ROOT/./packages/b/b.0.0.6/opam: failed to parse opam file:
+  'At ./<none>:13:12-13:13::
+  Parse error'
   [1]
 
 Test that we can run just the opam-file tests (i.e., the checks for maintainer


### PR DESCRIPTION
We had an error recently in CI that was tricky to figure out because it was unclear what kind of error it was (e.g., due to parsing versions or bad format or something else), and which position it was arising from in the file.

This improvement reuses `opam-format`'s error reporting logic to give a more useful errors messages, that includes the position of the error.

Thanks go @mikejeuga for flagging the issue!