### PR TITLE
Remove double checks for source archive checksums

### DIFF
--- a/opam-ci-check/bin/main.ml
+++ b/opam-ci-check/bin/main.ml
@@ -338,7 +338,7 @@ let lint_cmd =
         "primary-repo", Opam_repo_publication;
         "archive-repo", Opam_repo_archive])
     in
-    let defaults = Lint.Checks.[General_opam_file; Opam_repo_publication] in
+    let defaults = Lint.Checks.[Opam_repo_publication] in
     Arg.value (Arg.opt options defaults info)
   in
   let term =

--- a/opam-ci-check/lint/opam_ci_check_lint.ml
+++ b/opam-ci-check/lint/opam_ci_check_lint.ml
@@ -309,8 +309,8 @@ module Checks = struct
     | [] -> []
     | _ -> [ (pkg, DefaultTagsPresent default_tags_present) ]
 
-  let opam_lint ~pkg opam =
-    OpamFileTools.lint ~check_upstream:true opam
+  let opam_lint ~check_upstream ~pkg opam =
+    OpamFileTools.lint ~check_upstream opam
     |> List.map (fun x -> (pkg, OpamLint x))
 
   let is_perm_correct file =
@@ -453,9 +453,9 @@ module Checks = struct
     | _ -> [(pkg, InvalidOpamRepositoryCommitHash)]
 
   let checks kinds ~newly_published ~opam_repo_dir ~pkg_src_dir repo_package_names =
-    let general_opam_file_checks () =
+    let general_opam_file_checks ?(check_upstream=true) () =
       [
-        opam_lint;
+        opam_lint ~check_upstream;
       ]
     in
     let opam_repo_publication_checks () =
@@ -492,7 +492,9 @@ module Checks = struct
     List.concat_map
       (function
         | General_opam_file -> general_opam_file_checks ()
-        | Opam_repo_publication -> opam_repo_publication_checks ()
+        | Opam_repo_publication ->
+            general_opam_file_checks ~check_upstream:false () @
+            opam_repo_publication_checks ()
         | Opam_repo_archive -> opam_repo_archive_checks ())
       kinds
 


### PR DESCRIPTION
The [opam lint with `--check-upstream`](https://github.com/ocurrent/opam-repo-ci/blob/12810c8cc0b9a02e7b22f660387b76c6e70aa685/opam-ci-check/lint/opam_ci_check_lint.ml#L313) ensures that the [checksums for the upstream archive](https://github.com/ocaml/opam/blob/39165180cda81e8778b2ac9bb6eab363eac92261/src/state/opamFileTools.ml#L823-L850) is correct. But, we also have a separate `check_checksums` that also ensures this. This commit removes the double checksum check in the default case, but keeps the check when running with only "--checks opam-file".

This partially addresses #400.