### PR TITLE
 ocaml-{base-compiler,compiler} trigger addition of `--update-invariants`

### DIFF
--- a/opam-ci-check/lib/opam_build.ml
+++ b/opam-ci-check/lib/opam_build.ml
@@ -48,7 +48,9 @@ let opam_install ~variant ~opam_version ~pin ~lower_bounds ~with_tests ~pkg =
     in
     let verbose = if with_tests then " --verbose" else "" in
     let update_invariant =
-      if String.equal (OpamPackage.name_to_string pkg) "ocaml-variants" then
+      if List.mem (OpamPackage.name_to_string pkg)
+          ["ocaml-variants"; "ocaml-base-compiler"; "ocaml-compiler"]
+      then
         " --update-invariant"
       else ""
     in

--- a/opam-ci-check/test/build.t
+++ b/opam-ci-check/test/build.t
@@ -169,3 +169,105 @@ Test the build command:
       test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
       exit 1
   
+
+  $ opam-ci-check build ocaml-variants.5.3.1+trunk --only-print
+  FROM ocaml/opam:debian-12-ocaml-5.3
+  USER 1000:1000
+  WORKDIR /home/opam
+  RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
+  RUN opam init --reinit -ni
+  RUN opam option solver=builtin-0install && opam config report
+  ENV OPAMDOWNLOADJOBS="1"
+  ENV OPAMERRLOGLEN="0"
+  ENV OPAMPRECISETRACKING="1"
+  ENV CI="true"
+  ENV OPAM_REPO_CI="true"
+  RUN rm -rf opam-repository/
+  COPY --chown=1000:1000 . opam-repository/
+  RUN opam repository set-url --strict default opam-repository/
+  RUN opam update --depexts || true
+  RUN opam pin add -k version -yn ocaml-variants.5.3.1+trunk 5.3.1+trunk
+  RUN opam reinstall --update-invariant ocaml-variants.5.3.1+trunk; \
+      res=$?; \
+      test "$res" != 31 && exit "$res"; \
+      export OPAMCLI=2.0; \
+      build_dir=$(opam var prefix)/.opam-switch/build; \
+      failed=$(ls "$build_dir"); \
+      partial_fails=""; \
+      for pkg in $failed; do \
+      if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
+      echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+      fi; \
+      test "$pkg" != 'ocaml-variants.5.3.1+trunk' && partial_fails="$partial_fails $pkg"; \
+      done; \
+      test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+      exit 1
+  
+
+  $ opam-ci-check build ocaml-compiler.5.4.0 --only-print
+  FROM ocaml/opam:debian-12-ocaml-5.3
+  USER 1000:1000
+  WORKDIR /home/opam
+  RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
+  RUN opam init --reinit -ni
+  RUN opam option solver=builtin-0install && opam config report
+  ENV OPAMDOWNLOADJOBS="1"
+  ENV OPAMERRLOGLEN="0"
+  ENV OPAMPRECISETRACKING="1"
+  ENV CI="true"
+  ENV OPAM_REPO_CI="true"
+  RUN rm -rf opam-repository/
+  COPY --chown=1000:1000 . opam-repository/
+  RUN opam repository set-url --strict default opam-repository/
+  RUN opam update --depexts || true
+  RUN opam pin add -k version -yn ocaml-compiler.5.4.0 5.4.0
+  RUN opam reinstall ocaml-compiler.5.4.0; \
+      res=$?; \
+      test "$res" != 31 && exit "$res"; \
+      export OPAMCLI=2.0; \
+      build_dir=$(opam var prefix)/.opam-switch/build; \
+      failed=$(ls "$build_dir"); \
+      partial_fails=""; \
+      for pkg in $failed; do \
+      if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
+      echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+      fi; \
+      test "$pkg" != 'ocaml-compiler.5.4.0' && partial_fails="$partial_fails $pkg"; \
+      done; \
+      test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+      exit 1
+  
+
+  $ opam-ci-check build ocaml-base-compiler.5.3.0 --only-print
+  FROM ocaml/opam:debian-12-ocaml-5.3
+  USER 1000:1000
+  WORKDIR /home/opam
+  RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
+  RUN opam init --reinit -ni
+  RUN opam option solver=builtin-0install && opam config report
+  ENV OPAMDOWNLOADJOBS="1"
+  ENV OPAMERRLOGLEN="0"
+  ENV OPAMPRECISETRACKING="1"
+  ENV CI="true"
+  ENV OPAM_REPO_CI="true"
+  RUN rm -rf opam-repository/
+  COPY --chown=1000:1000 . opam-repository/
+  RUN opam repository set-url --strict default opam-repository/
+  RUN opam update --depexts || true
+  RUN opam pin add -k version -yn ocaml-base-compiler.5.3.0 5.3.0
+  RUN opam reinstall ocaml-base-compiler.5.3.0; \
+      res=$?; \
+      test "$res" != 31 && exit "$res"; \
+      export OPAMCLI=2.0; \
+      build_dir=$(opam var prefix)/.opam-switch/build; \
+      failed=$(ls "$build_dir"); \
+      partial_fails=""; \
+      for pkg in $failed; do \
+      if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-12\""; then \
+      echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+      fi; \
+      test "$pkg" != 'ocaml-base-compiler.5.3.0' && partial_fails="$partial_fails $pkg"; \
+      done; \
+      test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+      exit 1
+  

--- a/opam-ci-check/test/build.t
+++ b/opam-ci-check/test/build.t
@@ -221,7 +221,7 @@ Test the build command:
   RUN opam repository set-url --strict default opam-repository/
   RUN opam update --depexts || true
   RUN opam pin add -k version -yn ocaml-compiler.5.4.0 5.4.0
-  RUN opam reinstall ocaml-compiler.5.4.0; \
+  RUN opam reinstall --update-invariant ocaml-compiler.5.4.0; \
       res=$?; \
       test "$res" != 31 && exit "$res"; \
       export OPAMCLI=2.0; \
@@ -255,7 +255,7 @@ Test the build command:
   RUN opam repository set-url --strict default opam-repository/
   RUN opam update --depexts || true
   RUN opam pin add -k version -yn ocaml-base-compiler.5.3.0 5.3.0
-  RUN opam reinstall ocaml-base-compiler.5.3.0; \
+  RUN opam reinstall --update-invariant ocaml-base-compiler.5.3.0; \
       res=$?; \
       test "$res" != 31 && exit "$res"; \
       export OPAMCLI=2.0; \


### PR DESCRIPTION
Previously, only ocaml-variants packages would trigger addition of
`--update-invariants` when reinstalling the packages. This commit adds
ocaml-compiler and ocaml-base-compiler packages to the list of packages
that have this behavior.

Closes #408