### PR TITLE
lower-bounds: run the check with the opam-repository-archive on

### DIFF
--- a/opam-ci-check/lib/opam_build.ml
+++ b/opam-ci-check/lib/opam_build.ml
@@ -19,6 +19,7 @@ let opam_install ~variant ~opam_version ~pin ~lower_bounds ~with_tests ~pkg =
        env "OPAMCRITERIA"        "+removed,+count[version-lag,solution]";
        env "OPAMFIXUPCRITERIA"   "+removed,+count[version-lag,solution]";
        env "OPAMUPGRADECRITERIA" "+removed,+count[version-lag,solution]";
+       run "opam repository add archive https://github.com/ocaml/opam-repository-archive";
      ]
    else
      []


### PR DESCRIPTION
Currently the opam-repository will test the lower bound on most latest versions of packages. And even though most cases are avoided by the fact that we add upper bounds to all archived packages, the new packages may still be compatible and co-installable. So we should keep checking the lower bounds with the whole database to ensure that the metadata on the opam-repository remains consistent.

This will also help to ensure that all the people that use the archive in their CI do not have unpleasant surprises.