### PR TITLE
Minor fixes to opam-ci-check-lint

### DIFF
--- a/opam-ci-check/bin/main.ml
+++ b/opam-ci-check/bin/main.ml
@@ -225,7 +225,7 @@ let use_dune_term =
   Arg.value (Arg.flag info)
 
 let pkg_term =
-  let info = Arg.info [] ~doc:"Package name + version" in
+  let info = Arg.info [] ~doc:"Package <name.version>" ~docv:"pkg" in
   Arg.required (Arg.pos 0 (Arg.some Arg.string) None info)
 
 let split_on_first c s =
@@ -302,6 +302,7 @@ let package_specs_term =
   in
   let info =
     Arg.info []
+      ~docv:"pkg_spec"
       ~doc:
         "List of package specifications (format: \
          <name.version>[:src=<path>][,new=<true|false>]). If [src] is not \

--- a/opam-ci-check/bin/main.ml
+++ b/opam-ci-check/bin/main.ml
@@ -286,7 +286,7 @@ let package_specs_term =
           Error
             (`Msg
               (Printf.sprintf
-                 "%s is an not a valid attribute. Only [src=<path>] or \
+                 "%s is not a valid attribute. Only [src=<path>] or \
                   [new=<true|false>] allowed"
                  s))
     in

--- a/opam-ci-check/bin/main.ml
+++ b/opam-ci-check/bin/main.ml
@@ -309,8 +309,8 @@ let package_specs_term =
          specified, the sources are downloaded from the source URL. If [new] \
          is not specified, it is inferred from the opam repository."
   in
-  let+ pgk_spec_data = Arg.value (Arg.pos_all package_spec_conv [] info) in
-  pgk_spec_data
+  let+ pkg_spec_data = Arg.value (Arg.pos_all package_spec_conv [] info) in
+  pkg_spec_data
   |> List.map (fun (pkg, specs) ->
          let src =
            List.find_map (function `Src s -> Some s | _ -> None) specs

--- a/opam-ci-check/test/lint.t
+++ b/opam-ci-check/test/lint.t
@@ -23,22 +23,23 @@ Test for invalid attributes that are properly formed
 
 Test for an invalid values to a valid key
 
-  $ opam-ci-check lint -r . 'foo.0.1.0:new=invalid'
-  opam-ci-check: pkg_spec… arguments: invalid element in list
-                 ('new=invalid'): invalid must be [true] or [false]
-  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]…
-  Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information.
-  [124]
+# NOTE: We get rid of the line breaks in the output to work around
+# differences in UTF-8 length calculation between OCaml 5.4 and older
+# versions of OCaml.
+# See https://github.com/ocaml/ocaml/commit/1ef454907b19fba693a182296594d5b8024fa6f4 and
+# https://github.com/ocaml/ocaml/commit/d643794245c17e87bda08924e19a680673de7429
+
+  $ opam-ci-check lint -r . 'foo.0.1.0:new=invalid' 2>&1 | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g'
+  opam-ci-check: pkg_spec… arguments: invalid element in list ('new=invalid'): invalid must be [true] or [false] Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]… Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information. 
 
 Test for a missing value
 
-  $ opam-ci-check lint -r . 'foo.0.1.0:src='
-  opam-ci-check: pkg_spec… arguments: invalid element in list ('src='): src=
-                 is not a valid attribute. Only [src=<path>] or
-                 [new=<true|false>] allowed
-  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]…
-  Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information.
-  [124]
+# NOTE: We get rid of the line breaks in the output to work around
+# differences in UTF-8 length calculation between OCaml 5.4 and older
+# versions of OCaml.
+
+  $ opam-ci-check lint -r . 'foo.0.1.0:src=' 2>&1 | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g'
+  opam-ci-check: pkg_spec… arguments: invalid element in list ('src='): src= is not a valid attribute. Only [src=<path>] or [new=<true|false>] allowed Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]… Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information. 
 
 Test for a valid key with no value
 

--- a/opam-ci-check/test/lint.t
+++ b/opam-ci-check/test/lint.t
@@ -15,7 +15,7 @@ Test for invalid attributes that are properly formed
 
   $ opam-ci-check lint -r . 'foo.0.1.0:bar=baz'
   opam-ci-check: pkg_spec… arguments: invalid element in list ('bar=baz'):
-                 bar=baz is an not a valid attribute. Only [src=<path>] or
+                 bar=baz is not a valid attribute. Only [src=<path>] or
                  [new=<true|false>] allowed
   Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]…
   Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information.
@@ -34,7 +34,7 @@ Test for a missing value
 
   $ opam-ci-check lint -r . 'foo.0.1.0:src='
   opam-ci-check: pkg_spec… arguments: invalid element in list ('src='): src=
-                 is an not a valid attribute. Only [src=<path>] or
+                 is not a valid attribute. Only [src=<path>] or
                  [new=<true|false>] allowed
   Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]…
   Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information.
@@ -44,8 +44,8 @@ Test for a valid key with no value
 
   $ opam-ci-check lint -r . 'foo.0.1.0:src'
   opam-ci-check: pkg_spec… arguments: invalid element in list ('src'): src is
-                 an not a valid attribute. Only [src=<path>] or
-                 [new=<true|false>] allowed
+                 not a valid attribute. Only [src=<path>] or [new=<true|false>]
+                 allowed
   Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]…
   Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information.
   [124]

--- a/opam-ci-check/test/lint.t
+++ b/opam-ci-check/test/lint.t
@@ -3,9 +3,9 @@
 Test for an invalid package spec
 
   $ opam-ci-check lint -r . '=-~!:new=true'
-  opam-ci-check: invalid value '=-~!', expected opam package spec in the form
-                 <name.version>
-  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [ARG]…
+  opam-ci-check: pkg_spec… arguments: invalid value '=-~!', expected opam
+                 package spec in the form <name.version>
+  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]…
   Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information.
   [124]
 
@@ -14,54 +14,58 @@ Test for an invalid attributes
 Test for invalid attributes that are properly formed
 
   $ opam-ci-check lint -r . 'foo.0.1.0:bar=baz'
-  opam-ci-check: invalid element in list ('bar=baz'): bar=baz is an not a valid
-                 attribute. Only [src=<path>] or [new=<true|false>] allowed
-  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [ARG]…
+  opam-ci-check: pkg_spec… arguments: invalid element in list ('bar=baz'):
+                 bar=baz is an not a valid attribute. Only [src=<path>] or
+                 [new=<true|false>] allowed
+  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]…
   Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information.
   [124]
 
 Test for an invalid values to a valid key
 
   $ opam-ci-check lint -r . 'foo.0.1.0:new=invalid'
-  opam-ci-check: invalid element in list ('new=invalid'): invalid must be
-                 [true] or [false]
-  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [ARG]…
+  opam-ci-check: pkg_spec… arguments: invalid element in list
+                 ('new=invalid'): invalid must be [true] or [false]
+  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]…
   Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information.
   [124]
 
 Test for a missing value
 
   $ opam-ci-check lint -r . 'foo.0.1.0:src='
-  opam-ci-check: invalid element in list ('src='): src= is an not a valid
-                 attribute. Only [src=<path>] or [new=<true|false>] allowed
-  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [ARG]…
+  opam-ci-check: pkg_spec… arguments: invalid element in list ('src='): src=
+                 is an not a valid attribute. Only [src=<path>] or
+                 [new=<true|false>] allowed
+  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]…
   Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information.
   [124]
 
 Test for a valid key with no value
 
   $ opam-ci-check lint -r . 'foo.0.1.0:src'
-  opam-ci-check: invalid element in list ('src'): src is an not a valid
-                 attribute. Only [src=<path>] or [new=<true|false>] allowed
-  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [ARG]…
+  opam-ci-check: pkg_spec… arguments: invalid element in list ('src'): src is
+                 an not a valid attribute. Only [src=<path>] or
+                 [new=<true|false>] allowed
+  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]…
   Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information.
   [124]
 
 Test for `src` with a non-existent directory
 
   $ opam-ci-check lint -r . 'foo.0.1.0:src=./not/a/dir'
-  opam-ci-check: invalid element in list ('src=./not/a/dir'): ./not/a/dir: No
-                 such file or directory
-  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [ARG]…
+  opam-ci-check: pkg_spec… arguments: invalid element in list
+                 ('src=./not/a/dir'): ./not/a/dir: No such file or directory
+  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]…
   Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information.
   [124]
 
 Test for invalid extra colons
 
   $ opam-ci-check lint -r . 'foo.0.1.0:bing-bong:bang'
-  opam-ci-check: Invalid argument spec foo.0.1.0:bing-bong:bang. Argument specs
-                 should be of the form arg[:k1=v1[,k2=v2]]
-  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [ARG]…
+  opam-ci-check: pkg_spec… arguments: Invalid argument spec
+                 foo.0.1.0:bing-bong:bang. Argument specs should be of the form
+                 arg[:k1=v1[,k2=v2]]
+  Usage: opam-ci-check lint [--checks=VAL] [--quiet] [--opam-repository=VAL] [OPTION]… [pkg_spec]…
   Try 'opam-ci-check lint --help' or 'opam-ci-check --help' for more information.
   [124]
 


### PR DESCRIPTION
- Fixes a minor typo in a variable name
- Makes sure positional arguments are displayed in `--help`
- Updates cram tests with latest versions of `ocaml-version` and `dockerfile`