### PR TITLE
Update to ocaml-version 4.1 and drop Aarch32/I386 testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ocaml/opam:debian-13-ocaml-4.14 AS build
-RUN sudo ln -f /usr/bin/opam-2.4 /usr/bin/opam && opam init --reinit -ni
+RUN sudo ln -f /usr/bin/opam-2.5 /usr/bin/opam && opam init --reinit -ni
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto graphviz m4 pkg-config libsqlite3-dev libgmp-dev libffi-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard 2bf2bf6ea0c8867eede5e26c1c591999dd5a9ee1 && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 4375a073acc0d5f99f83516238d79308cefa9cab && opam update
 COPY --chown=opam opam-repo-ci-service.opam opam-repo-ci-api.opam opam-ci-check.opam /src/
 WORKDIR /src
 ENV OPAMSOLVERTIMEOUT=900

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ocaml/opam:debian-13-ocaml-4.14 AS build
 RUN sudo ln -f /usr/bin/opam-2.5 /usr/bin/opam && opam init --reinit -ni
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto graphviz m4 pkg-config libsqlite3-dev libgmp-dev libffi-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard 4375a073acc0d5f99f83516238d79308cefa9cab && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 9e0a49a82187f4efe4f6beb9e9796cee116f8dcf && opam update
 COPY --chown=opam opam-repo-ci-service.opam opam-repo-ci-api.opam opam-ci-check.opam /src/
 WORKDIR /src
 ENV OPAMSOLVERTIMEOUT=900

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,7 +1,7 @@
 FROM ocaml/opam:debian-13-ocaml-4.14 AS build
-RUN sudo ln -f /usr/bin/opam-2.4 /usr/bin/opam && opam init --reinit -ni
+RUN sudo ln -f /usr/bin/opam-2.5 /usr/bin/opam && opam init --reinit -ni
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev libffi-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard 2bf2bf6ea0c8867eede5e26c1c591999dd5a9ee1 && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 4375a073acc0d5f99f83516238d79308cefa9cab && opam update
 COPY --chown=opam opam-repo-ci-api.opam opam-repo-ci-web.opam opam-repo-ci-service.opam opam-ci-check.opam /src/
 WORKDIR /src
 RUN opam install -y --deps-only .

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,7 +1,7 @@
 FROM ocaml/opam:debian-13-ocaml-4.14 AS build
 RUN sudo ln -f /usr/bin/opam-2.5 /usr/bin/opam && opam init --reinit -ni
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev libffi-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard 4375a073acc0d5f99f83516238d79308cefa9cab && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 9e0a49a82187f4efe4f6beb9e9796cee116f8dcf && opam update
 COPY --chown=opam opam-repo-ci-api.opam opam-repo-ci-web.opam opam-repo-ci-service.opam opam-ci-check.opam /src/
 WORKDIR /src
 RUN opam install -y --deps-only .

--- a/doc/platforms.md
+++ b/doc/platforms.md
@@ -2,7 +2,7 @@
 
 ## Operating Systems
 
-- alpine-3.22
+- alpine-3.23
 - archlinux
 - centos-10
 - centos-9
@@ -21,13 +21,12 @@
 - ubuntu-24.04
 - ubuntu-25.04
 - ubuntu-25.10
+- ubuntu-26.04
 
 ## Architectures
 
 - amd64
-- arm32v7
 - arm64
-- i386
 - ppc64le
 - riscv64
 - s390x
@@ -35,11 +34,7 @@
 ## OCaml Versions
 
 - 4.08
-- 4.09
-- 4.10
 - 4.11
-- 4.12
-- 4.13
 - 4.14
 - 4.14-afl
 - 4.14-flambda
@@ -48,21 +43,20 @@
 - 4.14-nnp
 - 4.14-nnpchecker
 - 4.14-no-flat-float-array
-- 5.0
-- 5.1
 - 5.2
 - 5.3
 - 5.4
 - 5.4-afl
 - 5.4-flambda
 - 5.4-no-flat-float-array
+- 5.5~beta1
 
 ## Platforms Matrix
 
 |  OS | Arch | OCaml version |Opam version | Test lower-bounds | Test reverse dependencies |
 | --- | --- | --- | --- | --- | --- |
-| alpine-3.22 | amd64 | 4.14 | dev | No | No |
-| alpine-3.22 | amd64 | 5.4 | dev | No | No |
+| alpine-3.23 | amd64 | 4.14 | dev | No | No |
+| alpine-3.23 | amd64 | 5.4 | dev | No | No |
 | archlinux | amd64 | 4.14 | dev | No | No |
 | archlinux | amd64 | 5.4 | dev | No | No |
 | centos-10 | amd64 | 4.14 | dev | No | No |
@@ -72,11 +66,7 @@
 | debian-12 | amd64 | 4.14 | dev | No | No |
 | debian-12 | amd64 | 5.4 | dev | No | No |
 | debian-13 | amd64 | 4.08 | dev | Yes | No |
-| debian-13 | amd64 | 4.09 | dev | Yes | No |
-| debian-13 | amd64 | 4.10 | dev | Yes | No |
 | debian-13 | amd64 | 4.11 | dev | Yes | No |
-| debian-13 | amd64 | 4.12 | dev | Yes | No |
-| debian-13 | amd64 | 4.13 | dev | Yes | No |
 | debian-13 | amd64 | 4.14 | dev | Yes | Yes |
 | debian-13 | amd64 | 4.14-afl | dev | No | No |
 | debian-13 | amd64 | 4.14-flambda | dev | No | No |
@@ -85,20 +75,15 @@
 | debian-13 | amd64 | 4.14-nnp | dev | No | No |
 | debian-13 | amd64 | 4.14-nnpchecker | dev | No | No |
 | debian-13 | amd64 | 4.14-no-flat-float-array | dev | No | No |
-| debian-13 | amd64 | 5.0 | dev | Yes | No |
-| debian-13 | amd64 | 5.1 | dev | Yes | No |
 | debian-13 | amd64 | 5.2 | dev | Yes | No |
 | debian-13 | amd64 | 5.3 | dev | Yes | No |
 | debian-13 | amd64 | 5.4 | dev | Yes | Yes |
 | debian-13 | amd64 | 5.4-afl | dev | No | No |
 | debian-13 | amd64 | 5.4-flambda | dev | No | No |
 | debian-13 | amd64 | 5.4-no-flat-float-array | dev | No | No |
-| debian-13 | arm32v7 | 4.14 | dev | No | No |
-| debian-13 | arm32v7 | 5.4 | dev | No | No |
+| debian-13 | amd64 | 5.5~beta1 | dev | Yes | No |
 | debian-13 | arm64 | 4.14 | dev | No | No |
 | debian-13 | arm64 | 5.4 | dev | No | No |
-| debian-13 | i386 | 4.14 | dev | No | No |
-| debian-13 | i386 | 5.4 | dev | No | No |
 | debian-13 | ppc64le | 4.14 | dev | No | No |
 | debian-13 | ppc64le | 5.4 | dev | No | No |
 | debian-13 | s390x | 4.14 | dev | No | No |
@@ -127,9 +112,11 @@
 | ubuntu-22.04 | amd64 | 5.4 | dev | No | No |
 | ubuntu-24.04 | amd64 | 4.14 | dev | No | No |
 | ubuntu-24.04 | amd64 | 5.4 | dev | No | No |
-| ubuntu-24.04 | riscv64 | 4.14 | dev | No | No |
-| ubuntu-24.04 | riscv64 | 5.4 | dev | No | No |
 | ubuntu-25.04 | amd64 | 4.14 | dev | No | No |
 | ubuntu-25.04 | amd64 | 5.4 | dev | No | No |
 | ubuntu-25.10 | amd64 | 4.14 | dev | No | No |
 | ubuntu-25.10 | amd64 | 5.4 | dev | No | No |
+| ubuntu-26.04 | amd64 | 4.14 | dev | No | No |
+| ubuntu-26.04 | amd64 | 5.4 | dev | No | No |
+| ubuntu-26.04 | riscv64 | 4.14 | dev | No | No |
+| ubuntu-26.04 | riscv64 | 5.4 | dev | No | No |

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -145,7 +145,7 @@ let extras ~build =
     in
     let arches =
       List.filter_map (function
-        | `X86_64 -> None
+        | `X86_64 | `Aarch32 | `I386 -> None
         | `Riscv64 ->
             let label = Ocaml_version.to_opam_arch `Riscv64 in
             let riscv_distro = (Distro.resolve_alias (`Ubuntu `LTS) :> Distro.t) in

--- a/opam-ci-check.opam
+++ b/opam-ci-check.opam
@@ -24,7 +24,7 @@ depends: [
   "fpath" {>= "0.7.3"}
   "cmdliner" {>= "1.1.1"}
   "opam-client" {>= "2.3.0~alpha1"}
-  "ocaml-version" {>= "4.0.0"}
+  "ocaml-version" {>= "4.1.0"}
   "dockerfile-opam" {>= "6.3.0"}
   "obuilder-spec" {>= "0.6.0"}
   "odoc" {with-doc}

--- a/opam-ci-check.opam
+++ b/opam-ci-check.opam
@@ -23,9 +23,9 @@ depends: [
   "bos" {>= "0.2.1"}
   "fpath" {>= "0.7.3"}
   "cmdliner" {>= "1.1.1"}
-  "opam-client" {>= "2.3.0~alpha1"}
+  "opam-client" {>= "2.4.0"}
   "ocaml-version" {>= "4.1.0"}
-  "dockerfile-opam" {>= "6.3.0"}
+  "dockerfile-opam" {>= "8.3.6"}
   "obuilder-spec" {>= "0.6.0"}
   "odoc" {with-doc}
   "ppx_deriving" {>= "5.2.1"}

--- a/opam-ci-check.opam
+++ b/opam-ci-check.opam
@@ -23,7 +23,7 @@ depends: [
   "bos" {>= "0.2.1"}
   "fpath" {>= "0.7.3"}
   "cmdliner" {>= "1.1.1"}
-  "opam-client" {>= "2.4.0"}
+  "opam-client" {>= "2.5.0"}
   "ocaml-version" {>= "4.1.0"}
   "dockerfile-opam" {>= "8.3.6"}
   "obuilder-spec" {>= "0.6.0"}

--- a/opam-ci-check/lib/compiler_version.ml
+++ b/opam-ci-check/lib/compiler_version.ml
@@ -4,4 +4,4 @@
 
 (** Data describing and manipulating supported compilers versions *)
 
-let all_supported = Ocaml_version.Releases.recent @ Ocaml_version.Releases.unreleased_betas
+let all_supported = Ocaml_version.Releases.significant @ Ocaml_version.Releases.unreleased_betas

--- a/opam-ci-check/lib/test.mli
+++ b/opam-ci-check/lib/test.mli
@@ -29,4 +29,4 @@ val build_run_spec :
   ?opam_repository:string ->
   base:Spec.base ->
   Spec.t ->
-  (unit, Rresult.R.msg) result
+  (unit, [ `Msg of string ]) result

--- a/opam-repo-ci-api.opam
+++ b/opam-repo-ci-api.opam
@@ -16,8 +16,8 @@ depends: [
   "current_rpc"
   "capnp" {>= "3.4.0"}
   "capnp-rpc-lwt"
-  "dockerfile" {>= "8.2.3"}
-  "dockerfile-opam" {>= "8.2.3"}
+  "dockerfile" {>= "8.3.6"}
+  "dockerfile-opam" {>= "8.3.6"}
   "odoc" {with-doc}
   "current" {>= "0.6.6"}
   "current_docker"
@@ -27,8 +27,8 @@ depends: [
   "mula" {>= "0.1.2"}
   "obuilder-spec" {>= "0.6.0"}
   "ocaml-version" {>= "4.1.0"}
-  "opam-format" {>= "2.3.0~alpha1"}
-  "opam-state" {>= "2.3.0~alpha1"}
+  "opam-format" {>= "2.4.0"}
+  "opam-state" {>= "2.4.0"}
   "ppx_deriving" {>= "5.2.1"}
   "ppx_deriving_yojson"
   "sexplib" {>= "v0.16.0"}

--- a/opam-repo-ci-api.opam
+++ b/opam-repo-ci-api.opam
@@ -26,7 +26,7 @@ depends: [
   "logs"
   "mula" {>= "0.1.2"}
   "obuilder-spec" {>= "0.6.0"}
-  "ocaml-version" {>= "4.0.0"}
+  "ocaml-version" {>= "4.1.0"}
   "opam-format" {>= "2.3.0~alpha1"}
   "opam-state" {>= "2.3.0~alpha1"}
   "ppx_deriving" {>= "5.2.1"}

--- a/opam-repo-ci-api.opam
+++ b/opam-repo-ci-api.opam
@@ -27,8 +27,8 @@ depends: [
   "mula" {>= "0.1.2"}
   "obuilder-spec" {>= "0.6.0"}
   "ocaml-version" {>= "4.1.0"}
-  "opam-format" {>= "2.4.0"}
-  "opam-state" {>= "2.4.0"}
+  "opam-format" {>= "2.5.0"}
+  "opam-state" {>= "2.5.0"}
   "ppx_deriving" {>= "5.2.1"}
   "ppx_deriving_yojson"
   "sexplib" {>= "v0.16.0"}

--- a/opam-repo-ci-service.opam
+++ b/opam-repo-ci-service.opam
@@ -35,8 +35,8 @@ depends: [
   "memtrace" {>= "0.1.1"}
   "capnp-rpc-lwt" {>= "0.8.0"}
   "capnp-rpc-unix" {>= "0.8.0"}
-  "opam-state" {>= "2.4.0"}
-  "opam-format" {>= "2.4.0"}
+  "opam-state" {>= "2.5.0"}
+  "opam-format" {>= "2.5.0"}
   "opam-file-format" {>= "2.1.2"}
   "sexplib" {>= "v0.14.0"}
   "conf-libev"

--- a/opam-repo-ci-service.opam
+++ b/opam-repo-ci-service.opam
@@ -35,13 +35,13 @@ depends: [
   "memtrace" {>= "0.1.1"}
   "capnp-rpc-lwt" {>= "0.8.0"}
   "capnp-rpc-unix" {>= "0.8.0"}
-  "opam-state" {>= "2.3.0~alpha1"}
-  "opam-format" {>= "2.3.0~alpha1"}
+  "opam-state" {>= "2.4.0"}
+  "opam-format" {>= "2.4.0"}
   "opam-file-format" {>= "2.1.2"}
   "sexplib" {>= "v0.14.0"}
   "conf-libev"
-  "dockerfile" {>= "8.2.3"}
-  "dockerfile-opam" {>= "8.2.3"}
+  "dockerfile" {>= "8.3.6"}
+  "dockerfile-opam" {>= "8.3.6"}
   "ocaml-version" {>= "4.1.0"}
   "mula" {>= "0.1.2"}
   "alcotest" {>= "1.0.0" & with-test}

--- a/opam-repo-ci-service.opam
+++ b/opam-repo-ci-service.opam
@@ -42,7 +42,7 @@ depends: [
   "conf-libev"
   "dockerfile" {>= "8.2.3"}
   "dockerfile-opam" {>= "8.2.3"}
-  "ocaml-version" {>= "4.0.0"}
+  "ocaml-version" {>= "4.1.0"}
   "mula" {>= "0.1.2"}
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}

--- a/opam-repo-ci-web.opam
+++ b/opam-repo-ci-web.opam
@@ -39,8 +39,8 @@ depends: [
   "odoc" {with-doc}
   "capnp-rpc-lwt" {>= "1.2.3"}
   "mula" {>= "0.1.2"}
-  "opam-format" {>= "2.4.0"}
-  "opam-state" {>= "2.4.0"}
+  "opam-format" {>= "2.5.0"}
+  "opam-state" {>= "2.5.0"}
   "ppx_deriving" {>= "5.2.1"}
   "sexplib" {>= "v0.16.0"}
 ]

--- a/opam-repo-ci-web.opam
+++ b/opam-repo-ci-web.opam
@@ -22,8 +22,8 @@ depends: [
   "current_ocluster"
   "current_docker"
   "current_github"
-  "dockerfile" {>= "8.2.3"}
-  "dockerfile-opam" {>= "8.2.3"}
+  "dockerfile" {>= "8.3.6"}
+  "dockerfile-opam" {>= "8.3.6"}
   "obuilder-spec"
   "ocaml-version"
   "prometheus-app"
@@ -39,8 +39,8 @@ depends: [
   "odoc" {with-doc}
   "capnp-rpc-lwt" {>= "1.2.3"}
   "mula" {>= "0.1.2"}
-  "opam-format" {>= "2.3.0~alpha1"}
-  "opam-state" {>= "2.3.0~alpha1"}
+  "opam-format" {>= "2.4.0"}
+  "opam-state" {>= "2.4.0"}
   "ppx_deriving" {>= "5.2.1"}
   "sexplib" {>= "v0.16.0"}
 ]

--- a/stack.yml
+++ b/stack.yml
@@ -33,6 +33,7 @@ services:
     volumes:
       - 'data:/var/lib/ocurrent'
       - 'capnp-secrets:/capnp-secrets'
+      - '/archive:/archive:ro'
     secrets:
       - 'opam-repo-ci-oauth'
       - 'opam-repo-ci-github-key'

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -82,174 +82,6 @@ build: debian-13-ocaml-4.08/amd64 opam-dev lower-bounds
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-13-ocaml-4.09/amd64 opam-dev
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-4.09/amd64 opam-dev lower-bounds
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-    ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
-    ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
-    ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-4.10/amd64 opam-dev
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-4.10/amd64 opam-dev lower-bounds
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-    ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
-    ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
-    ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
 build: debian-13-ocaml-4.11/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
@@ -284,174 +116,6 @@ build: debian-13-ocaml-4.11/amd64 opam-dev
         exit 1
 
 build: debian-13-ocaml-4.11/amd64 opam-dev lower-bounds
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-    ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
-    ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
-    ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-4.12/amd64 opam-dev
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-4.12/amd64 opam-dev lower-bounds
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-    ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
-    ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
-    ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-4.13/amd64 opam-dev
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-4.13/amd64 opam-dev lower-bounds
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -638,174 +302,6 @@ build: debian-13-ocaml-4.14/amd64 opam-dev with-tests
         exit 1
     RUN (opam reinstall --with-test a.0.0.1) || true
     RUN opam reinstall --with-test --verbose a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-5.0/amd64 opam-dev
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-5.0/amd64 opam-dev lower-bounds
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-    ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
-    ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
-    ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-5.1/amd64 opam-dev
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-5.1/amd64 opam-dev lower-bounds
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-    ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
-    ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
-    ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
         export OPAMCLI=2.0; \
@@ -1125,6 +621,90 @@ build: debian-13-ocaml-5.4/amd64 opam-dev with-tests
         exit 1
     RUN (opam reinstall --with-test a.0.0.1) || true
     RUN opam reinstall --with-test --verbose a.0.0.1; \
+        res=$?; \
+        test "$res" != 31 && exit "$res"; \
+        export OPAMCLI=2.0; \
+        build_dir=$(opam var prefix)/.opam-switch/build; \
+        failed=$(ls "$build_dir"); \
+        partial_fails=""; \
+        for pkg in $failed; do \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
+        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+        fi; \
+        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
+        done; \
+        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+        exit 1
+
+build: debian-13-ocaml-5.5-beta1/amd64 opam-dev
+    FROM BASE_IMAGE_TAG
+    USER 1000:1000
+    WORKDIR /home/opam
+    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
+    RUN opam init --reinit -ni
+    RUN opam option solver=builtin-0install && opam config report
+    ENV OPAMDOWNLOADJOBS="1"
+    ENV OPAMERRLOGLEN="0"
+    ENV OPAMPRECISETRACKING="1"
+    ENV CI="true"
+    ENV OPAM_REPO_CI="true"
+    RUN rm -rf opam-repository/
+    COPY --chown=1000:1000 . opam-repository/
+    RUN opam repository set-url --strict default opam-repository/
+    RUN opam update --depexts || true
+    RUN opam pin add -k version -yn a.0.0.1 0.0.1
+    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
+        res=$?; \
+        test "$res" != 31 && exit "$res"; \
+        export OPAMCLI=2.0; \
+        build_dir=$(opam var prefix)/.opam-switch/build; \
+        failed=$(ls "$build_dir"); \
+        partial_fails=""; \
+        for pkg in $failed; do \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
+        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+        fi; \
+        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
+        done; \
+        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+        exit 1
+
+build: debian-13-ocaml-5.5-beta1/amd64 opam-dev lower-bounds
+    FROM BASE_IMAGE_TAG
+    USER 1000:1000
+    WORKDIR /home/opam
+    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
+    RUN opam init --reinit -ni
+    RUN opam option solver=builtin-0install && opam config report
+    ENV OPAMDOWNLOADJOBS="1"
+    ENV OPAMERRLOGLEN="0"
+    ENV OPAMPRECISETRACKING="1"
+    ENV CI="true"
+    ENV OPAM_REPO_CI="true"
+    RUN rm -rf opam-repository/
+    COPY --chown=1000:1000 . opam-repository/
+    RUN opam repository set-url --strict default opam-repository/
+    RUN opam update --depexts || true
+    RUN opam pin add -k version -yn a.0.0.1 0.0.1
+    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
+        res=$?; \
+        test "$res" != 31 && exit "$res"; \
+        export OPAMCLI=2.0; \
+        build_dir=$(opam var prefix)/.opam-switch/build; \
+        failed=$(ls "$build_dir"); \
+        partial_fails=""; \
+        for pkg in $failed; do \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
+        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+        fi; \
+        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
+        done; \
+        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+        exit 1
+    ENV OPAMCRITERIA="+removed,+count[version-lag,solution]"
+    ENV OPAMFIXUPCRITERIA="+removed,+count[version-lag,solution]"
+    ENV OPAMUPGRADECRITERIA="+removed,+count[version-lag,solution]"
+    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
         res=$?; \
         test "$res" != 31 && exit "$res"; \
         export OPAMCLI=2.0; \
@@ -1635,7 +1215,7 @@ build: archlinux-ocaml-5.4/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: alpine-3.22-ocaml-5.4/amd64 opam-dev
+build: alpine-3.23-ocaml-5.4/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1660,7 +1240,7 @@ build: alpine-3.22-ocaml-5.4/amd64 opam-dev
         failed=$(ls "$build_dir"); \
         partial_fails=""; \
         for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"alpine-3.22\""; then \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"alpine-3.23\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
@@ -2163,7 +1743,7 @@ build: archlinux-ocaml-4.14/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: alpine-3.22-ocaml-4.14/amd64 opam-dev
+build: alpine-3.23-ocaml-4.14/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2188,7 +1768,7 @@ build: alpine-3.22-ocaml-4.14/amd64 opam-dev
         failed=$(ls "$build_dir"); \
         partial_fails=""; \
         for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"alpine-3.22\""; then \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"alpine-3.23\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
@@ -2687,40 +2267,6 @@ build: debian-13-ocaml-5.4-no-flat-float-array/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-13-ocaml-5.4/i386 opam-dev
-    FROM BASE_IMAGE_TAG
-    SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
 build: debian-13-ocaml-5.4/arm64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
@@ -2756,40 +2302,6 @@ build: debian-13-ocaml-5.4/arm64 opam-dev
 
 build: debian-13-ocaml-5.4/ppc64le opam-dev
     FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-5.4/arm32v7 opam-dev
-    FROM BASE_IMAGE_TAG
-    SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
@@ -3316,40 +2828,6 @@ build: debian-13-ocaml-4.14-nnpchecker/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-13-ocaml-4.14/i386 opam-dev
-    FROM BASE_IMAGE_TAG
-    SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
 build: debian-13-ocaml-4.14/arm64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
@@ -3385,40 +2863,6 @@ build: debian-13-ocaml-4.14/arm64 opam-dev
 
 build: debian-13-ocaml-4.14/ppc64le opam-dev
     FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam option solver=builtin-0install && opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam update --depexts || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-4.14/arm32v7 opam-dev
-    FROM BASE_IMAGE_TAG
-    SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -720,6 +720,39 @@ build: debian-13-ocaml-5.5-beta1/amd64 opam-dev lower-bounds
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
+build: ubuntu-26.04-ocaml-5.4/amd64 opam-dev
+    FROM BASE_IMAGE_TAG
+    USER 1000:1000
+    WORKDIR /home/opam
+    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
+    RUN opam init --reinit -ni
+    RUN opam option solver=builtin-0install && opam config report
+    ENV OPAMDOWNLOADJOBS="1"
+    ENV OPAMERRLOGLEN="0"
+    ENV OPAMPRECISETRACKING="1"
+    ENV CI="true"
+    ENV OPAM_REPO_CI="true"
+    RUN rm -rf opam-repository/
+    COPY --chown=1000:1000 . opam-repository/
+    RUN opam repository set-url --strict default opam-repository/
+    RUN opam update --depexts || true
+    RUN opam pin add -k version -yn a.0.0.1 0.0.1
+    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
+        res=$?; \
+        test "$res" != 31 && exit "$res"; \
+        export OPAMCLI=2.0; \
+        build_dir=$(opam var prefix)/.opam-switch/build; \
+        failed=$(ls "$build_dir"); \
+        partial_fails=""; \
+        for pkg in $failed; do \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"ubuntu-26.04\""; then \
+        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+        fi; \
+        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
+        done; \
+        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+        exit 1
+
 build: ubuntu-25.10-ocaml-5.4/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
@@ -1241,6 +1274,39 @@ build: alpine-3.23-ocaml-5.4/amd64 opam-dev
         partial_fails=""; \
         for pkg in $failed; do \
         if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"alpine-3.23\""; then \
+        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
+        fi; \
+        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
+        done; \
+        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
+        exit 1
+
+build: ubuntu-26.04-ocaml-4.14/amd64 opam-dev
+    FROM BASE_IMAGE_TAG
+    USER 1000:1000
+    WORKDIR /home/opam
+    RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
+    RUN opam init --reinit -ni
+    RUN opam option solver=builtin-0install && opam config report
+    ENV OPAMDOWNLOADJOBS="1"
+    ENV OPAMERRLOGLEN="0"
+    ENV OPAMPRECISETRACKING="1"
+    ENV CI="true"
+    ENV OPAM_REPO_CI="true"
+    RUN rm -rf opam-repository/
+    COPY --chown=1000:1000 . opam-repository/
+    RUN opam repository set-url --strict default opam-repository/
+    RUN opam update --depexts || true
+    RUN opam pin add -k version -yn a.0.0.1 0.0.1
+    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam reinstall a.0.0.1; \
+        res=$?; \
+        test "$res" != 31 && exit "$res"; \
+        export OPAMCLI=2.0; \
+        build_dir=$(opam var prefix)/.opam-switch/build; \
+        failed=$(ls "$build_dir"); \
+        partial_fails=""; \
+        for pkg in $failed; do \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"ubuntu-26.04\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
@@ -2366,7 +2432,7 @@ build: debian-13-ocaml-5.4/s390x opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: ubuntu-24.04-ocaml-5.4/riscv64 opam-dev
+build: ubuntu-26.04-ocaml-5.4/riscv64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2391,7 +2457,7 @@ build: ubuntu-24.04-ocaml-5.4/riscv64 opam-dev
         failed=$(ls "$build_dir"); \
         partial_fails=""; \
         for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"ubuntu-24.04\""; then \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"ubuntu-26.04\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
@@ -2927,7 +2993,7 @@ build: debian-13-ocaml-4.14/s390x opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: ubuntu-24.04-ocaml-4.14/riscv64 opam-dev
+build: ubuntu-26.04-ocaml-4.14/riscv64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2952,7 +3018,7 @@ build: ubuntu-24.04-ocaml-4.14/riscv64 opam-dev
         failed=$(ls "$build_dir"); \
         partial_fails=""; \
         for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"ubuntu-24.04\""; then \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"ubuntu-26.04\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \


### PR DESCRIPTION
- Update to ocaml-version-4.1.0 to access the latest compiler versions and betas
- Switched to `Ocaml_version.Releases.significant` to drop the tested compiler versions from 11 to 6.
- Removed arm32 and i386 testing
- Switch to Alpine 3.23 (from 3.22)
- Add Ubuntu 25.10 and 26.04

Closes #467