### PR TITLE
Pin riscv64 distro to Ubuntu 24.04

### DIFF
--- a/doc/platforms.md
+++ b/doc/platforms.md
@@ -112,11 +112,11 @@
 | ubuntu-22.04 | amd64 | 5.4 | dev | No | No |
 | ubuntu-24.04 | amd64 | 4.14 | dev | No | No |
 | ubuntu-24.04 | amd64 | 5.4 | dev | No | No |
+| ubuntu-24.04 | riscv64 | 4.14 | dev | No | No |
+| ubuntu-24.04 | riscv64 | 5.4 | dev | No | No |
 | ubuntu-25.04 | amd64 | 4.14 | dev | No | No |
 | ubuntu-25.04 | amd64 | 5.4 | dev | No | No |
 | ubuntu-25.10 | amd64 | 4.14 | dev | No | No |
 | ubuntu-25.10 | amd64 | 5.4 | dev | No | No |
 | ubuntu-26.04 | amd64 | 4.14 | dev | No | No |
 | ubuntu-26.04 | amd64 | 5.4 | dev | No | No |
-| ubuntu-26.04 | riscv64 | 4.14 | dev | No | No |
-| ubuntu-26.04 | riscv64 | 5.4 | dev | No | No |

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -148,8 +148,9 @@ let extras ~build =
         | `X86_64 | `Aarch32 | `I386 -> None
         | `Riscv64 ->
             let label = Ocaml_version.to_opam_arch `Riscv64 in
-            let riscv_distro = (Distro.resolve_alias (`Ubuntu `LTS) :> Distro.t) in
-            let riscv_distro = Distro.tag_of_distro riscv_distro in
+            (* Pinned to 24.04: should track `Ubuntu `LTS, but we lack the
+               hardware to build ocaml/opam riscv64 images for newer LTSes. *)
+            let riscv_distro = Distro.tag_of_distro (`Ubuntu `V24_04) in
             Some (build ~opam_version ~arch:`Riscv64 ~distro:riscv_distro ~compiler:(comp, None) label)
         | arch ->
             let label = Ocaml_version.to_opam_arch arch in

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -2432,7 +2432,7 @@ build: debian-13-ocaml-5.4/s390x opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: ubuntu-26.04-ocaml-5.4/riscv64 opam-dev
+build: ubuntu-24.04-ocaml-5.4/riscv64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -2457,7 +2457,7 @@ build: ubuntu-26.04-ocaml-5.4/riscv64 opam-dev
         failed=$(ls "$build_dir"); \
         partial_fails=""; \
         for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"ubuntu-26.04\""; then \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"ubuntu-24.04\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
@@ -2993,7 +2993,7 @@ build: debian-13-ocaml-4.14/s390x opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: ubuntu-26.04-ocaml-4.14/riscv64 opam-dev
+build: ubuntu-24.04-ocaml-4.14/riscv64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -3018,7 +3018,7 @@ build: ubuntu-26.04-ocaml-4.14/riscv64 opam-dev
         failed=$(ls "$build_dir"); \
         partial_fails=""; \
         for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"ubuntu-26.04\""; then \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"ubuntu-24.04\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \


### PR DESCRIPTION
The `Ubuntu LTS alias now resolves to 26.04, but ocaml/opam has no riscv64 image for that tag, so Docker.peek fails. Pin explicitly to 24.04 until riscv64 hardware is available to build newer LTS images.