### PR TITLE
Remove opam 2.0 support

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -160,7 +160,7 @@ let extras ~build =
     List.map (fun opam_version ->
       let opam_string = "opam-" ^ Opam_version.to_string opam_version in
       build ~opam_version ~arch:`X86_64 ~distro:master_distro ~compiler:(comp, None) opam_string)
-      [ `V2_0; `V2_1; `V2_2; `V2_3; `V2_4; `V2_5 ] @
+      [ `V2_1; `V2_2; `V2_3; `V2_4; `V2_5 ] @
     switches @ arches @ acc
   ) [] default_compilers_full
 

--- a/opam-ci-check/lib/opam_build.ml
+++ b/opam-ci-check/lib/opam_build.ml
@@ -1,5 +1,3 @@
-let fmt = Fmt.str
-
 let download_cache = "opam-archives"
 let cache ~variant =
   match Variant.os variant with
@@ -9,7 +7,7 @@ let cache ~variant =
                 Obuilder_spec.Cache.v "homebrew" ~target:"/Users/mac1000/Library/Caches/Homebrew" ]
 let network = ["host"]
 
-let opam_install ~variant ~opam_version ~pin ~lower_bounds ~with_tests ~pkg =
+let opam_install ~variant ~pin ~lower_bounds ~with_tests ~pkg =
   let pkg_s = OpamPackage.to_string pkg in
   let with_tests_opt = if with_tests then " --with-test" else "" in
   let cache = cache ~variant in
@@ -35,17 +33,11 @@ let opam_install ~variant ~opam_version ~pin ~lower_bounds ~with_tests ~pkg =
   (if with_tests then [
      (* TODO: Remove this hack when https://github.com/ocurrent/obuilder/issues/77 is fixed *)
      (* NOTE: This hack will fail for packages that have src: "git+https://..." *)
-     run ~network "(%sopam reinstall --with-test %s) || true"
-       (match opam_version with `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 | `Dev -> "" | `V2_0 -> fmt "opam depext%s %s && " with_tests_opt pkg_s) pkg_s
+     run ~network "(opam reinstall --with-test %s) || true" pkg_s
    ] else []) @ [
     (* TODO: Replace by two calls to opam install + opam install -t using the OPAMDROPINSTALLEDPACKAGES feature *)
     (* NOTE: See above for the ~network:(if with_tests ...) hack *)
     (* NOTE: We cannot use the cache as concurrent access to the cache might overwrite it and the required archives might not be available anymore at this point *)
-    let depext =
-      match opam_version with
-      | `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 | `Dev -> ""
-      | `V2_0 -> fmt "opam depext%s %s && " with_tests_opt pkg_s
-    in
     let verbose = if with_tests then " --verbose" else "" in
     let update_invariant =
       if List.mem (OpamPackage.name_to_string pkg)
@@ -55,7 +47,7 @@ let opam_install ~variant ~opam_version ~pin ~lower_bounds ~with_tests ~pkg =
       else ""
     in
     run ~cache:(if with_tests then [] else cache) ~network:(if with_tests then [] else network)
-      {|%sopam reinstall%s%s%s %s;
+      {|opam reinstall%s%s%s %s;
         res=$?;
         test "$res" != 31 && exit "$res";
         export OPAMCLI=2.0;
@@ -70,7 +62,7 @@ let opam_install ~variant ~opam_version ~pin ~lower_bounds ~with_tests ~pkg =
         done;
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}";
         exit 1|}
-      depext with_tests_opt verbose update_invariant pkg_s
+      with_tests_opt verbose update_invariant pkg_s
       (Variant.distribution variant)
       pkg_s
   ]
@@ -117,7 +109,7 @@ let setup_repository ?(local=false) ~variant ~for_docker ~opam_version () =
      Otherwise the "opam pin" after the "opam repository set-url" will fail (cannot find the new package for some reason) *)
   run "%s -f %s/bin/opam-%s %s/bin/opam" ln prefix opam_version_str prefix ::
   run ~network "opam init --reinit%s -ni" opamrc :: (* TODO: Remove ~network when https://github.com/ocurrent/ocaml-dockerfile/pull/132 is merged *)
-  run "%sopam config report" (match opam_version with `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 | `Dev -> "opam option solver=builtin-0install && " | `V2_0 -> "") ::
+  run "opam option solver=builtin-0install && opam config report" ::
   env "OPAMDOWNLOADJOBS" "1" :: (* Try to avoid github spam detection *)
   env "OPAMERRLOGLEN" "0" :: (* Show the whole log if it fails *)
   env "OPAMPRECISETRACKING" "1" :: (* Mitigate https://github.com/ocaml/opam/issues/3997 *)
@@ -126,7 +118,7 @@ let setup_repository ?(local=false) ~variant ~for_docker ~opam_version () =
     run "rm -rf opam-repository/";
     copy ["."] ~dst:"opam-repository/";
     run "opam repository set-url%s --strict default opam-repository/" opam_repo_args;
-    run ~network "opam %s || true" (match opam_version with `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 | `Dev -> "update --depexts" | `V2_0 -> "depext -u");
+    run ~network "opam update --depexts || true";
   ] @
   if local then [ keep_installed ] else []
 
@@ -137,7 +129,7 @@ let set_personality ~variant =
     []
 
 let spec ?(local=false) ~for_docker ~opam_version ~base ~variant ~revdep ~lower_bounds ~with_tests ~pkg () =
-  let opam_install = opam_install ~variant ~opam_version in
+  let opam_install = opam_install ~variant in
   let revdep = match revdep with
     | None -> []
     | Some revdep -> opam_install ~pin:false ~lower_bounds:false ~with_tests:false ~pkg:revdep

--- a/opam-ci-check/lib/opam_version.ml
+++ b/opam-ci-check/lib/opam_version.ml
@@ -1,4 +1,4 @@
-type t = [ `Dev | `V2_0 | `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 ] [@@deriving to_yojson]
+type t = [ `Dev | `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 ] [@@deriving to_yojson]
 
 let to_string = function
   | `Dev -> "dev"
@@ -7,4 +7,3 @@ let to_string = function
   | `V2_3 -> "2.3"
   | `V2_2 -> "2.2"
   | `V2_1 -> "2.1"
-  | `V2_0 -> "2.0"

--- a/opam-ci-check/lib/opam_version.mli
+++ b/opam-ci-check/lib/opam_version.mli
@@ -1,3 +1,3 @@
-type t = [ `Dev | `V2_0 | `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 ] [@@deriving to_yojson]
+type t = [ `Dev | `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 ] [@@deriving to_yojson]
 
 val to_string : t -> string

--- a/opam-ci-check/lib/spec.mli
+++ b/opam-ci-check/lib/spec.mli
@@ -22,7 +22,7 @@ type opam_build = {
 
 (** Configuration for a [list_revdeps] job *)
 type list_revdeps = {
-  opam_version : [ `Dev | `V2_0 | `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 ];
+  opam_version : [ `Dev | `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 ];
 }
 
 (** Configuration for any job along with the package to build *)

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -2036,39 +2036,6 @@ build: freebsd-15.0-ocaml-4.14/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: debian-13-ocaml-5.4/amd64 opam-2.0
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-2.0 /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam depext -u || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam depext a.0.0.1 && opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
 build: debian-13-ocaml-5.4/amd64 opam-2.1
     FROM BASE_IMAGE_TAG
     USER 1000:1000
@@ -2458,39 +2425,6 @@ build: ubuntu-24.04-ocaml-5.4/riscv64 opam-dev
         partial_fails=""; \
         for pkg in $failed; do \
         if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"ubuntu-24.04\""; then \
-        echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
-        fi; \
-        test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
-        done; \
-        test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
-        exit 1
-
-build: debian-13-ocaml-4.14/amd64 opam-2.0
-    FROM BASE_IMAGE_TAG
-    USER 1000:1000
-    WORKDIR /home/opam
-    RUN sudo ln -f /usr/bin/opam-2.0 /usr/bin/opam
-    RUN opam init --reinit -ni
-    RUN opam config report
-    ENV OPAMDOWNLOADJOBS="1"
-    ENV OPAMERRLOGLEN="0"
-    ENV OPAMPRECISETRACKING="1"
-    ENV CI="true"
-    ENV OPAM_REPO_CI="true"
-    RUN rm -rf opam-repository/
-    COPY --chown=1000:1000 . opam-repository/
-    RUN opam repository set-url --strict default opam-repository/
-    RUN opam depext -u || true
-    RUN opam pin add -k version -yn a.0.0.1 0.0.1
-    RUN --mount=type=cache,id=opam-archives,target=/home/opam/.opam/download-cache,uid=1000 opam depext a.0.0.1 && opam reinstall a.0.0.1; \
-        res=$?; \
-        test "$res" != 31 && exit "$res"; \
-        export OPAMCLI=2.0; \
-        build_dir=$(opam var prefix)/.opam-switch/build; \
-        failed=$(ls "$build_dir"); \
-        partial_fails=""; \
-        for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"debian-13\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \


### PR DESCRIPTION
Drops the V2_0 constructor from Opam_ci_check.Opam_version and the
extras() revdep matrix in lib/build.ml. The 2.0-specific depext
branches in opam_build.ml collapse to their V2_1+ form (no spec
changes for any non-2.0 build).

Prepares for ocurrent/docker-base-images#342 and upstream
ocurrent/ocaml-dockerfile#262 to remove the opam-2.0 base images:
this PR removes the consumer-side dependency first so those changes
won't break opam-repo-ci.