### PR TITLE
Update README.md to fix installation instructions

### DIFF
--- a/opam-ci-check/README.md
+++ b/opam-ci-check/README.md
@@ -9,6 +9,7 @@ This tool is in progress.
 ## Installation
 
 ``` sh
+opam pin opam-ci-check-lint https://github.com/ocurrent/opam-repo-ci.git 
 opam pin opam-ci-check https://github.com/ocurrent/opam-repo-ci.git
 ```
 


### PR DESCRIPTION
The current instructions fail because `opam-ci-check-lint` is a prerequisite of the subsequent command.