### PR TITLE
Enable proof-of-work browser challenge on the engine web UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ RUN cd ~/opam-repository && git fetch origin master && git reset --hard ceed23f9
 COPY --chown=opam opam-repo-ci-service.opam opam-repo-ci-api.opam opam-ci-check.opam /src/
 WORKDIR /src
 RUN opam option --global solver=builtin-0install
+RUN opam pin add -yn current.dev         "https://github.com/mtelvers/ocurrent.git#cb9fe87b717c102a73bdda00ca461d8875ec7882" && \
+    opam pin add -yn current_web.dev     "https://github.com/mtelvers/ocurrent.git#cb9fe87b717c102a73bdda00ca461d8875ec7882" && \
+    opam pin add -yn current_git.dev     "https://github.com/mtelvers/ocurrent.git#cb9fe87b717c102a73bdda00ca461d8875ec7882" && \
+    opam pin add -yn current_github.dev  "https://github.com/mtelvers/ocurrent.git#cb9fe87b717c102a73bdda00ca461d8875ec7882" && \
+    opam pin add -yn current_docker.dev  "https://github.com/mtelvers/ocurrent.git#cb9fe87b717c102a73bdda00ca461d8875ec7882" && \
+    opam pin add -yn current_slack.dev   "https://github.com/mtelvers/ocurrent.git#cb9fe87b717c102a73bdda00ca461d8875ec7882" && \
+    opam pin add -yn current_rpc.dev     "https://github.com/mtelvers/ocurrent.git#cb9fe87b717c102a73bdda00ca461d8875ec7882"
 RUN opam install -y --deps-only .
 ADD --chown=opam . .
 RUN opam exec -- dune build ./_build/install/default/bin/opam-repo-ci-service ./_build/install/default/bin/opam-ci-check

--- a/service/main.ml
+++ b/service/main.ml
@@ -141,8 +141,22 @@ let main config mode app capnp_address github_auth submission_uri prometheus_con
       else has_role
     in
     let routes = routes ~engine app github_auth in
+    (* Require a proof-of-work browser challenge before serving HTML pages, to
+       keep JavaScript-less crawlers off the (expensive) /job/ log pages.
+       Webhooks (POST) and /metrics are not GET-html, so they pass untouched. *)
+    let challenge =
+      (* Difficulty as leading zero bits; the browser solver does one async hash
+         per try, so keep it modest. Any value blocks JS-less crawlers (they
+         never solve it); difficulty only throttles JS-capable clients.
+         Override at runtime with POW_DIFFICULTY. *)
+      let difficulty =
+        Option.bind (Sys.getenv_opt "POW_DIFFICULTY") int_of_string_opt
+        |> Stdlib.Option.value ~default:12
+      in
+      Current_web.Challenge.v ~difficulty ()
+    in
     let site =
-      Current_web.Site.v ?authn ~has_role ~secure_cookies:true ~name:"opam-ci" routes
+      Current_web.Site.v ?authn ~has_role ~secure_cookies:true ~challenge ~name:"opam-ci" routes
     in
     let prometheus =
       List.map (Lwt.map @@ Result.ok) (Prometheus_unix.serve prometheus_config)


### PR DESCRIPTION
Pin ocurrent to the `current-web-challenge` branch and gate the engine's HTML pages behind `Current_web.Challenge` (difficulty via `POW_DIFFICULTY`, default 12). Keeps JS-less crawlers off `/job/`; webhooks and `/metrics` are unaffected. Depends on the matching ocurrent PR; repin to a release once that merges.