### PR TITLE
FreeBSD: bump distro from 15.0 to 15.1

### DIFF
--- a/doc/platforms.md
+++ b/doc/platforms.md
@@ -13,7 +13,7 @@
 - fedora-42
 - fedora-43
 - fedora-44
-- freebsd-15.0
+- freebsd-15.1
 - macos-homebrew
 - opensuse-16.0
 - opensuse-tumbleweed
@@ -94,8 +94,8 @@
 | fedora-43 | amd64 | 5.5 | dev | No | No |
 | fedora-44 | amd64 | 4.14 | dev | No | No |
 | fedora-44 | amd64 | 5.5 | dev | No | No |
-| freebsd-15.0 | amd64 | 4.14 | dev | No | No |
-| freebsd-15.0 | amd64 | 5.5 | dev | No | No |
+| freebsd-15.1 | amd64 | 4.14 | dev | No | No |
+| freebsd-15.1 | amd64 | 5.5 | dev | No | No |
 | macos-homebrew | amd64 | 4.14 | dev | No | No |
 | macos-homebrew | amd64 | 5.5 | dev | No | No |
 | macos-homebrew | arm64 | 4.14 | dev | No | No |

--- a/opam-ci-check/lib/variant.ml
+++ b/opam-ci-check/lib/variant.ml
@@ -27,7 +27,7 @@ let docker_tag t =
 let distribution t = t.distribution
 let pp f t = Fmt.pf f "%s/%s" (docker_tag t) (Ocaml_version.string_of_arch t.arch)
 
-let freebsd = "freebsd-15.0"
+let freebsd = "freebsd-15.1"
 let macos_homebrew = "macos-homebrew"
 
 let macos_distributions = [

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -1802,7 +1802,7 @@ build: macos-homebrew-ocaml-4.14/arm64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: freebsd-15.0-ocaml-5.5/amd64 opam-dev
+build: freebsd-15.1-ocaml-5.5/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1827,7 +1827,7 @@ build: freebsd-15.0-ocaml-5.5/amd64 opam-dev
         failed=$(ls "$build_dir"); \
         partial_fails=""; \
         for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"freebsd-15.0\""; then \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"freebsd-15.1\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \
@@ -1835,7 +1835,7 @@ build: freebsd-15.0-ocaml-5.5/amd64 opam-dev
         test "${partial_fails}" != "" && echo "opam-repo-ci detected dependencies failing: ${partial_fails}"; \
         exit 1
 
-build: freebsd-15.0-ocaml-4.14/amd64 opam-dev
+build: freebsd-15.1-ocaml-4.14/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     WORKDIR /home/opam
@@ -1860,7 +1860,7 @@ build: freebsd-15.0-ocaml-4.14/amd64 opam-dev
         failed=$(ls "$build_dir"); \
         partial_fails=""; \
         for pkg in $failed; do \
-        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"freebsd-15.0\""; then \
+        if opam show -f x-ci-accept-failures: "$pkg" | grep -qF "\"freebsd-15.1\""; then \
         echo "A package failed and has been disabled for CI using the 'x-ci-accept-failures' field."; \
         fi; \
         test "$pkg" != 'a.0.0.1' && partial_fails="$partial_fails $pkg"; \


### PR DESCRIPTION
Bumps the FreeBSD distro `freebsd-15.0`→`freebsd-15.1` to match the worker's base images rebuilt on FreeBSD 15.1-RELEASE. Build + tests pass (spec fixture updated). Companion to ocaml-ci #1065.