### PR TITLE
index: use GLOB not LIKE in get_full_hash to hit the PK index

### DIFF
--- a/lib/index.ml
+++ b/lib/index.ml
@@ -59,8 +59,13 @@ CREATE TABLE IF NOT EXISTS ci_build_index (
                                      WHERE owner = ? AND name = ? AND hash = ? AND variant = ?" in
   let get_job_ids = Sqlite3.prepare db "SELECT variant, job_id FROM ci_build_index \
                                      WHERE owner = ? AND name = ? AND hash = ?" in
+  (* GLOB (not LIKE) so the query uses the primary-key index: LIKE is
+     case-insensitive by default, which disables the index and forces a full
+     scan of the (millions-of-rows) table on every call. GLOB is case-sensitive
+     and its prefix pattern compiles to an indexed range seek. Git hashes are
+     lowercase hex, so case-sensitivity is a non-issue. *)
   let full_hash = Sqlite3.prepare db "SELECT DISTINCT hash FROM ci_build_index \
-                                      WHERE owner = ? AND name = ? AND hash LIKE ?" in
+                                      WHERE owner = ? AND name = ? AND hash GLOB ?" in
   {
     record_job;
     remove;
@@ -225,7 +230,7 @@ let get_full_hash ~owner ~name short_hash =
   let t = Lazy.force db in
   if is_valid_hash short_hash then (
     Log.info (fun f -> f "@[<h>Index.get_full_hash %s/%s %s@]" owner name short_hash);
-    match Db.query t.full_hash Sqlite3.Data.[ TEXT owner; TEXT name; TEXT (short_hash ^ "%") ] with
+    match Db.query t.full_hash Sqlite3.Data.[ TEXT owner; TEXT name; TEXT (short_hash ^ "*") ] with
     | [] -> Error `Unknown
     | [Sqlite3.Data.[ TEXT hash ]] -> Ok hash
     | [_] -> failwith "get_full_hash: invalid result!"


### PR DESCRIPTION
`get_full_hash` ran:

```sql
SELECT DISTINCT hash FROM ci_build_index WHERE owner = ? AND name = ? AND hash LIKE ?
```

SQLite's `LIKE` is **case-insensitive by default**, which disables the index for the `hash` term. So the query seeks to the `owner/name` prefix and then **scans every row under it** — for `ocaml/opam-repository` that is the entire **4.5M-row** `ci_build_index`. Because `get_full_hash` runs on every commit/variant page and the SQLite call is synchronous on the single Lwt thread, ~1 req/s saturates a core (measured **~0.97s CPU per call**), so any crawl of the web UI makes the engine unresponsive.

`GLOB` is case-sensitive, so its prefix pattern compiles to an **indexed range seek** (`hash>? AND hash<?`). Git hashes are lowercase hex, so case-sensitivity is a non-issue and the prefix / `Ambiguous` semantics are unchanged.

**Measured on the production 6.2 GB index** (`EXPLAIN QUERY PLAN` + `.timer`):

| query | plan | time |
|---|---|---|
| `hash LIKE 'H%'` (before) | `SEARCH (owner=? AND name=?)` → scan | 968 ms |
| `hash GLOB 'H*'` (after) | `SEARCH (… AND hash>? AND hash<?)` → range seek | 1 ms |

~900× faster; identical for full and short hashes. Root-caused via `perf` (96.9% of engine CPU was in libsqlite3, dominated by `VdbeExec`/`RecordCompareWithSkip`/`BtreeNext`).