### PR TITLE
Retry opam init to survive the opam 2.6 root layout upgrade

### DIFF
--- a/opam-ci-check/lib/opam_build.ml
+++ b/opam-ci-check/lib/opam_build.ml
@@ -108,7 +108,14 @@ let setup_repository ?(local=false) ~variant ~for_docker ~opam_version () =
   (* TODO: MacOS seems to have a bug in (copy ...) so I am forced to remove the (workdir ...) here.
      Otherwise the "opam pin" after the "opam repository set-url" will fail (cannot find the new package for some reason) *)
   run "%s -f %s/bin/opam-%s %s/bin/opam" ln prefix opam_version_str prefix ::
-  run ~network "opam init --reinit%s -ni" opamrc :: (* TODO: Remove ~network when https://github.com/ocurrent/ocaml-dockerfile/pull/132 is merged *)
+  (* NOTE: opam 2.6~alpha bumps the opam root layout from the 2.1 version the
+     base images ship with. On the first run it performs the migration and then
+     exits 10 (Aborted) with "Update done, please now retry your command", so we
+     have to run it again. No flag suppresses this (-y, --confirm-level,
+     OPAMNOAUTOUPGRADE and --cli=2.1 all still abort). The retry is conditional
+     so that opam versions needing no migration don't update the repositories,
+     and hit GitHub, twice per job. *)
+  run ~network "opam init --reinit%s -ni || opam init --reinit%s -ni" opamrc opamrc :: (* TODO: Remove ~network when https://github.com/ocurrent/ocaml-dockerfile/pull/132 is merged *)
   run "opam option solver=builtin-0install && opam config report" ::
   env "OPAMDOWNLOADJOBS" "1" :: (* Try to avoid github spam detection *)
   env "OPAMERRLOGLEN" "0" :: (* Show the whole log if it fails *)

--- a/opam-ci-check/test/build.t
+++ b/opam-ci-check/test/build.t
@@ -5,7 +5,7 @@ Test the build command:
   USER 1000:1000
   WORKDIR /home/opam
   RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-  RUN opam init --reinit -ni
+  RUN opam init --reinit -ni || opam init --reinit -ni
   RUN opam option solver=builtin-0install && opam config report
   ENV OPAMDOWNLOADJOBS="1"
   ENV OPAMERRLOGLEN="0"
@@ -55,7 +55,7 @@ Test the build command:
   USER 1000:1000
   WORKDIR /home/opam
   RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-  RUN opam init --reinit -ni
+  RUN opam init --reinit -ni || opam init --reinit -ni
   RUN opam option solver=builtin-0install && opam config report
   ENV OPAMDOWNLOADJOBS="1"
   ENV OPAMERRLOGLEN="0"
@@ -89,7 +89,7 @@ Test the build command:
   USER 1000:1000
   WORKDIR /home/opam
   RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-  RUN opam init --reinit -ni
+  RUN opam init --reinit -ni || opam init --reinit -ni
   RUN opam option solver=builtin-0install && opam config report
   ENV OPAMDOWNLOADJOBS="1"
   ENV OPAMERRLOGLEN="0"
@@ -141,7 +141,7 @@ Test the build command:
   USER 1000:1000
   WORKDIR /home/opam
   RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-  RUN opam init --reinit -ni
+  RUN opam init --reinit -ni || opam init --reinit -ni
   RUN opam option solver=builtin-0install && opam config report
   ENV OPAMDOWNLOADJOBS="1"
   ENV OPAMERRLOGLEN="0"
@@ -175,7 +175,7 @@ Test the build command:
   USER 1000:1000
   WORKDIR /home/opam
   RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-  RUN opam init --reinit -ni
+  RUN opam init --reinit -ni || opam init --reinit -ni
   RUN opam option solver=builtin-0install && opam config report
   ENV OPAMDOWNLOADJOBS="1"
   ENV OPAMERRLOGLEN="0"
@@ -209,7 +209,7 @@ Test the build command:
   USER 1000:1000
   WORKDIR /home/opam
   RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-  RUN opam init --reinit -ni
+  RUN opam init --reinit -ni || opam init --reinit -ni
   RUN opam option solver=builtin-0install && opam config report
   ENV OPAMDOWNLOADJOBS="1"
   ENV OPAMERRLOGLEN="0"
@@ -243,7 +243,7 @@ Test the build command:
   USER 1000:1000
   WORKDIR /home/opam
   RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-  RUN opam init --reinit -ni
+  RUN opam init --reinit -ni || opam init --reinit -ni
   RUN opam option solver=builtin-0install && opam config report
   ENV OPAMDOWNLOADJOBS="1"
   ENV OPAMERRLOGLEN="0"

--- a/test/specs.expected
+++ b/test/specs.expected
@@ -3,7 +3,7 @@ build: debian-13-ocaml-4.11/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -36,7 +36,7 @@ build: debian-13-ocaml-4.11/amd64 opam-dev lower-bounds
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -87,7 +87,7 @@ build: debian-13-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -120,7 +120,7 @@ build: debian-13-ocaml-4.14/amd64 opam-dev lower-bounds
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -171,7 +171,7 @@ list-revdeps: debian-13-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -189,7 +189,7 @@ build: debian-13-ocaml-4.14/amd64 opam-dev with-tests
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -238,7 +238,7 @@ build: debian-13-ocaml-5.2/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -271,7 +271,7 @@ build: debian-13-ocaml-5.2/amd64 opam-dev lower-bounds
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -322,7 +322,7 @@ build: debian-13-ocaml-5.4/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -355,7 +355,7 @@ build: debian-13-ocaml-5.4/amd64 opam-dev lower-bounds
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -406,7 +406,7 @@ build: debian-13-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -439,7 +439,7 @@ build: debian-13-ocaml-5.5/amd64 opam-dev lower-bounds
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -490,7 +490,7 @@ list-revdeps: debian-13-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -508,7 +508,7 @@ build: debian-13-ocaml-5.5/amd64 opam-dev with-tests
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -557,7 +557,7 @@ build: ubuntu-26.04-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -590,7 +590,7 @@ build: ubuntu-25.10-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -623,7 +623,7 @@ build: ubuntu-25.04-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -656,7 +656,7 @@ build: ubuntu-24.04-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -689,7 +689,7 @@ build: ubuntu-22.04-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -722,7 +722,7 @@ build: opensuse-tumbleweed-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -755,7 +755,7 @@ build: opensuse-16.0-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -788,7 +788,7 @@ build: fedora-44-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -821,7 +821,7 @@ build: fedora-43-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -854,7 +854,7 @@ build: fedora-42-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -887,7 +887,7 @@ build: debian-unstable-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -920,7 +920,7 @@ build: debian-testing-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -953,7 +953,7 @@ build: debian-12-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -986,7 +986,7 @@ build: centos-10-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1019,7 +1019,7 @@ build: centos-9-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1052,7 +1052,7 @@ build: archlinux-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1085,7 +1085,7 @@ build: alpine-3.23-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1118,7 +1118,7 @@ build: ubuntu-26.04-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1151,7 +1151,7 @@ build: ubuntu-25.10-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1184,7 +1184,7 @@ build: ubuntu-25.04-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1217,7 +1217,7 @@ build: ubuntu-24.04-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1250,7 +1250,7 @@ build: ubuntu-22.04-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1283,7 +1283,7 @@ build: opensuse-tumbleweed-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1316,7 +1316,7 @@ build: opensuse-16.0-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1349,7 +1349,7 @@ build: fedora-44-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1382,7 +1382,7 @@ build: fedora-43-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1415,7 +1415,7 @@ build: fedora-42-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1448,7 +1448,7 @@ build: debian-unstable-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1481,7 +1481,7 @@ build: debian-testing-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1514,7 +1514,7 @@ build: debian-12-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1547,7 +1547,7 @@ build: centos-10-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1580,7 +1580,7 @@ build: centos-9-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1613,7 +1613,7 @@ build: archlinux-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1646,7 +1646,7 @@ build: alpine-3.23-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1678,7 +1678,7 @@ build: macos-homebrew-ocaml-5.5/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     RUN ln -f ~/local/bin/opam-dev ~/local/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1710,7 +1710,7 @@ build: macos-homebrew-ocaml-5.5/arm64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     RUN ln -f ~/local/bin/opam-dev ~/local/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1742,7 +1742,7 @@ build: macos-homebrew-ocaml-4.14/amd64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     RUN ln -f ~/local/bin/opam-dev ~/local/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1774,7 +1774,7 @@ build: macos-homebrew-ocaml-4.14/arm64 opam-dev
     FROM BASE_IMAGE_TAG
     USER 1000:1000
     RUN ln -f ~/local/bin/opam-dev ~/local/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1807,7 +1807,7 @@ build: freebsd-15.1-ocaml-5.5/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/local/bin/opam-dev /usr/local/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1840,7 +1840,7 @@ build: freebsd-15.1-ocaml-4.14/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/local/bin/opam-dev /usr/local/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1873,7 +1873,7 @@ build: debian-13-ocaml-5.5/amd64 opam-2.1
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1906,7 +1906,7 @@ build: debian-13-ocaml-5.5/amd64 opam-2.2
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.2 /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1939,7 +1939,7 @@ build: debian-13-ocaml-5.5/amd64 opam-2.3
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.3 /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -1972,7 +1972,7 @@ build: debian-13-ocaml-5.5/amd64 opam-2.4
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.4 /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2005,7 +2005,7 @@ build: debian-13-ocaml-5.5/amd64 opam-2.5
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.5 /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2038,7 +2038,7 @@ build: debian-13-ocaml-5.5-afl/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2071,7 +2071,7 @@ build: debian-13-ocaml-5.5-flambda/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2104,7 +2104,7 @@ build: debian-13-ocaml-5.5-no-flat-float-array/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2137,7 +2137,7 @@ build: debian-13-ocaml-5.5/arm64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2170,7 +2170,7 @@ build: debian-13-ocaml-5.5/ppc64le opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2203,7 +2203,7 @@ build: debian-13-ocaml-5.5/s390x opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2236,7 +2236,7 @@ build: ubuntu-24.04-ocaml-5.5/riscv64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2269,7 +2269,7 @@ build: debian-13-ocaml-4.14/amd64 opam-2.1
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2302,7 +2302,7 @@ build: debian-13-ocaml-4.14/amd64 opam-2.2
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.2 /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2335,7 +2335,7 @@ build: debian-13-ocaml-4.14/amd64 opam-2.3
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.3 /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2368,7 +2368,7 @@ build: debian-13-ocaml-4.14/amd64 opam-2.4
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.4 /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2401,7 +2401,7 @@ build: debian-13-ocaml-4.14/amd64 opam-2.5
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-2.5 /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2434,7 +2434,7 @@ build: debian-13-ocaml-4.14-afl/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2467,7 +2467,7 @@ build: debian-13-ocaml-4.14-flambda/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2500,7 +2500,7 @@ build: debian-13-ocaml-4.14-fp/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2533,7 +2533,7 @@ build: debian-13-ocaml-4.14-flambda-fp/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2566,7 +2566,7 @@ build: debian-13-ocaml-4.14-no-flat-float-array/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2599,7 +2599,7 @@ build: debian-13-ocaml-4.14-nnp/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2632,7 +2632,7 @@ build: debian-13-ocaml-4.14-nnpchecker/amd64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2665,7 +2665,7 @@ build: debian-13-ocaml-4.14/arm64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2698,7 +2698,7 @@ build: debian-13-ocaml-4.14/ppc64le opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2731,7 +2731,7 @@ build: debian-13-ocaml-4.14/s390x opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"
@@ -2764,7 +2764,7 @@ build: ubuntu-24.04-ocaml-4.14/riscv64 opam-dev
     USER 1000:1000
     WORKDIR /home/opam
     RUN sudo ln -f /usr/bin/opam-dev /usr/bin/opam
-    RUN opam init --reinit -ni
+    RUN opam init --reinit -ni || opam init --reinit -ni
     RUN opam option solver=builtin-0install && opam config report
     ENV OPAMDOWNLOADJOBS="1"
     ENV OPAMERRLOGLEN="0"


### PR DESCRIPTION
`opam-dev` in the base images is now `2.6.0~alpha1`, which bumps the opam root layout from the version 2.1 the images ship with. On the first invocation `opam init --reinit` performs the migration, prints *"Update done, please now retry your command"* and exits **10** (Aborted), so every job using opam dev fails at setup — which, since `lib/build.ml` sets `opam_version = ` `` `Dev `` globally, is every build, test, lower-bounds and revdep job:

```
/home/opam: (run (network host)
                 (shell "opam init --reinit --config .opamrc-sandbox -ni"))
...
This version of opam requires an update to the layout of /home/opam/.opam from version 2.1 to version 2.6~alpha, which can't be reverted.
Perform the update and continue? [Y/n] y
...
Upgrading the internal repository format for 'default'...
Format upgrade done.

<><> Rerunning init and update ><><><><><><><><><><><><><><><><><><><><><><><><>
...
Update done, please now retry your command.
"/usr/bin/env" "bash" "-c" "opam init --reinit --config .opamrc-sandbox -ni" failed with exit status 10
```

Running the identical command a second time returns 0, and no flag suppresses the abort. Verified in `ocaml/opam:debian-testing-ocaml-4.14@sha256:00036ba6…`:

| attempt | exit |
| --- | --- |
| `opam init --reinit --config .opamrc-sandbox -ni` | 10 |
| … `-y` | 10 |
| … `--confirm-level=unsafe-yes` | 10 |
| … `OPAMNOAUTOUPGRADE=1` | 10 |
| … `--cli=2.1` | 10 |
| … `\|\| opam init --reinit … -ni` | **0** |

`--no-auto-upgrade`/`OPAMNOAUTOUPGRADE` only governs the *repository* format, not the root, and `opam init --help` has nothing for the root upgrade. Exit 10 is documented as *"Aborted. The operation required confirmation, which wasn't given"*, which is misleading here: the confirmation was auto-answered `y` and the migration succeeded. Arguably an opam bug — for `init` the command you are told to retry is the one that just ran — so this is a stopgap, and the commit message says to revert it once opam stops aborting. I'll raise it upstream.

The retry is conditional (`||`) rather than an unconditional second run because a successful `opam init --reinit` already updates the repositories, which fetches `ocaml-patches-overlay` from GitHub; running it twice on the opam versions needing no migration would double that traffic on every job, which is what `OPAMDOWNLOADJOBS=1` exists to avoid.

Released opam is unaffected — I checked `opam-2.5` (2.5.2) inits cleanly first time — so the `` `V2_1 ``…`` `V2_5 `` matrix jobs never hit the second invocation. After the fix the following `opam option solver=builtin-0install` step succeeds and the base packages survive the migration (`base-bigarray base-threads base-unix ocaml ocaml-base-compiler ocaml-config ocaml-options-vanilla opam-depext`).

Note this does **not** invalidate any cached results: `Cluster_build.Op.Key` is `{pool; commit; variant; ty}` and the spec string reaches `Op.build` through the unhashed `Op.t` context, so changing the spec text does not re-run existing jobs. (Same reason the weekly base-image digest refresh doesn't.) Jobs that have already failed with exit 10 keep their recorded failure until they are pushed to or rebuilt.

Tests promoted: `opam-ci-check/test/build.t` and `test/specs.expected`.